### PR TITLE
Timer improvements

### DIFF
--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -72,7 +72,7 @@
 
 -define(DEFAULT_CONFIG, #{
     % ticks/sec
-    tick_rate => 40,
+    tick_rate => 20,
     require_auth => false
 }).
 


### PR DESCRIPTION
We use the new & improved timer module in OTP 25.

Also rename TickRate to TickMs which is a bit more accurate. The handle_tick callback will get the tick timer directly instead of via map now.