### PR TITLE
Enet options

### DIFF
--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -118,7 +118,7 @@ func ws_connect(url: String, tls: bool):
 
 func enet_connect(ip: String, port: int):
 	print("[INFO] Connecting via ENet to ", ip)
-	var _err = _enet_peer.create_client(ip, port, 1)
+	var _err = _enet_peer.create_client(ip, port, 4)
 	mode = transport_mode.ENET
 
 func _send_message(payload, opcode, qos, channel):

--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -141,7 +141,15 @@ func _send_message(payload, opcode, qos, channel):
 			# TODO: Thread channel and packet type through
 			if payload.is_empty() != true:
 				packet.append_array(payload)
-			p.send(0, packet, ENetPacketPeer.FLAG_RELIABLE)
+			var flag
+			match qos:
+				"reliable":
+					flag = ENetPacketPeer.FLAG_RELIABLE
+				"unreliable":
+					flag = ENetPacketPeer.FLAG_UNRELIABLE_FRAGMENT
+				"unsequenced":
+					flag = ENetPacketPeer.FLAG_UNSEQUENCED
+			p.send(channel, packet, flag)
 
 func _process(_delta):
 	if mode == transport_mode.WEBSOCKET:

--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -121,9 +121,9 @@ func enet_connect(ip: String, port: int):
 	var _err = _enet_peer.create_client(ip, port, 1)
 	mode = transport_mode.ENET
 
-func _send_message(payload, opcode):
+func _send_message(payload, opcode, qos, channel):
 	# Create a new packet starting with opcode, append the message if it exists,
-	# then send it across the websocket.
+	# then send it across the websocket or ENet connection.
 	# Set the peer mode
 	var peer
 	if mode == transport_mode.WEBSOCKET:

--- a/src/ow_account.erl
+++ b/src/ow_account.erl
@@ -32,13 +32,17 @@ rpc_info() ->
             opcode => ?ACCOUNT_NEW,
             c2s_handler => {?MODULE, account_new, 2},
             s2c_call => gen_response,
-            encoder => overworld_pb
+            encoder => overworld_pb,
+            qos => reliable,
+            channel => 0
         },
         #{
             opcode => ?ACCOUNT_LOGIN,
             c2s_handler => {?MODULE, account_login, 2},
             s2c_call => gen_response,
-            encoder => overworld_pb
+            encoder => overworld_pb,
+            qos => reliable,
+            channel => 0
         }
     ].
 

--- a/src/ow_beacon.erl
+++ b/src/ow_beacon.erl
@@ -32,7 +32,9 @@ rpc_info() ->
         #{
             opcode => ?BEACON,
             s2c_call => session_beacon,
-            encoder => overworld_pb
+            encoder => overworld_pb,
+            qos => reliable,
+            channel => 0
         }
     ].
 

--- a/src/ow_binding.erl
+++ b/src/ow_binding.erl
@@ -463,13 +463,22 @@ generate_marshall(
         {_, ClientMsg, _} ->
             FunStr = opcode_name_string(OpInfo),
             Encoder = ow_rpc:encoder(OpInfo),
+            QOS = case ow_rpc:qos(OpInfo) of
+                      undefined -> "reliable";
+                      Type -> atom_to_list(Type)
+                  end,
+            Channel = case ow_rpc:channel(OpInfo) of
+                          undefined -> "0";
+                          Number -> integer_to_list(Number)
+                      end,
             Op =
                 case Encoder of
                     undefined ->
                         % define an empty message for ping
                         "func " ++ FunStr ++ "():\n" ++
                             ?TAB ++ "_send_message([], OpCode." ++
-                            string:to_upper(FunStr) ++ ")\n" ++
+                            string:to_upper(FunStr) ++ "," ++ QOS 
+                            ++ "," ++ Channel ++ ")\n" ++
                             ?TAB ++ "if debug:\n" ++
                             ?TAB(2) ++ "print('[INFO] Sent a " ++
                             FunStr ++
@@ -495,8 +504,8 @@ generate_marshall(
                             %set_parameters(Fields, Encoder) ++
                             ?TAB ++ "var payload = m.to_bytes()\n" ++
                             ?TAB ++ "_send_message(payload, OpCode." ++
-                            string:to_upper(FunStr) ++
-                            ")\n" ++
+                            string:to_upper(FunStr) ++ "," ++ QOS 
+                            ++ "," ++ Channel ++ ")\n" ++
                             ?TAB ++ "if debug:\n" ++
                             ?TAB(2) ++ "print('[INFO] Sent a " ++
                             FunStr ++

--- a/src/ow_binding.erl
+++ b/src/ow_binding.erl
@@ -463,22 +463,24 @@ generate_marshall(
         {_, ClientMsg, _} ->
             FunStr = opcode_name_string(OpInfo),
             Encoder = ow_rpc:encoder(OpInfo),
-            QOS = case ow_rpc:qos(OpInfo) of
-                      undefined -> "reliable";
-                      Type -> atom_to_list(Type)
-                  end,
-            Channel = case ow_rpc:channel(OpInfo) of
-                          undefined -> "0";
-                          Number -> integer_to_list(Number)
-                      end,
+            QOS =
+                case ow_rpc:qos(OpInfo) of
+                    undefined -> "reliable";
+                    Type -> atom_to_list(Type)
+                end,
+            Channel =
+                case ow_rpc:channel(OpInfo) of
+                    undefined -> "0";
+                    Number -> integer_to_list(Number)
+                end,
             Op =
                 case Encoder of
                     undefined ->
                         % define an empty message for ping
                         "func " ++ FunStr ++ "():\n" ++
                             ?TAB ++ "_send_message([], OpCode." ++
-                            string:to_upper(FunStr) ++ "," ++ QOS 
-                            ++ "," ++ Channel ++ ")\n" ++
+                            string:to_upper(FunStr) ++ "," ++ QOS ++
+                            "," ++ Channel ++ ")\n" ++
                             ?TAB ++ "if debug:\n" ++
                             ?TAB(2) ++ "print('[INFO] Sent a " ++
                             FunStr ++
@@ -504,8 +506,8 @@ generate_marshall(
                             %set_parameters(Fields, Encoder) ++
                             ?TAB ++ "var payload = m.to_bytes()\n" ++
                             ?TAB ++ "_send_message(payload, OpCode." ++
-                            string:to_upper(FunStr) ++ "," ++ QOS 
-                            ++ "," ++ Channel ++ ")\n" ++
+                            string:to_upper(FunStr) ++ "," ++ QOS ++
+                            "," ++ Channel ++ ")\n" ++
                             ?TAB ++ "if debug:\n" ++
                             ?TAB(2) ++ "print('[INFO] Sent a " ++
                             FunStr ++

--- a/src/ow_binding.erl
+++ b/src/ow_binding.erl
@@ -479,8 +479,8 @@ generate_marshall(
                         % define an empty message for ping
                         "func " ++ FunStr ++ "():\n" ++
                             ?TAB ++ "_send_message([], OpCode." ++
-                            string:to_upper(FunStr) ++ "," ++ QOS ++
-                            "," ++ Channel ++ ")\n" ++
+                            string:to_upper(FunStr) ++ ", '" ++ QOS ++
+                            "', " ++ Channel ++ ")\n" ++
                             ?TAB ++ "if debug:\n" ++
                             ?TAB(2) ++ "print('[INFO] Sent a " ++
                             FunStr ++
@@ -506,8 +506,8 @@ generate_marshall(
                             %set_parameters(Fields, Encoder) ++
                             ?TAB ++ "var payload = m.to_bytes()\n" ++
                             ?TAB ++ "_send_message(payload, OpCode." ++
-                            string:to_upper(FunStr) ++ "," ++ QOS ++
-                            "," ++ Channel ++ ")\n" ++
+                            string:to_upper(FunStr) ++ ", '" ++ QOS ++
+                            "', " ++ Channel ++ ")\n" ++
                             ?TAB ++ "if debug:\n" ++
                             ?TAB(2) ++ "print('[INFO] Sent a " ++
                             FunStr ++

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -125,6 +125,8 @@ decode_and_reply(Msg, IncomingChannel, {Mod, Fun}, State) ->
             ChannelPid = maps:get(IncomingChannel, Channels),
             erlang:apply(Mod, Fun, [ChannelPid, FlatMsg]),
             Session1;
+        {ok, Session1, {QOS, MsgChannel}} ->
+            Session1
         {Msg1, Session1, {QOS, MsgChannel}} ->
             channelize_msg(Msg1, Channels, {QOS, MsgChannel}),
             Session1

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -126,7 +126,7 @@ decode_and_reply(Msg, IncomingChannel, {Mod, Fun}, State) ->
             erlang:apply(Mod, Fun, [ChannelPid, FlatMsg]),
             Session1;
         {ok, Session1, {QOS, MsgChannel}} ->
-            Session1
+            Session1;
         {Msg1, Session1, {QOS, MsgChannel}} ->
             channelize_msg(Msg1, Channels, {QOS, MsgChannel}),
             Session1

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -125,7 +125,7 @@ decode_and_reply(Msg, IncomingChannel, {Mod, Fun}, State) ->
             ChannelPid = maps:get(IncomingChannel, Channels),
             erlang:apply(Mod, Fun, [ChannelPid, FlatMsg]),
             Session1;
-        {ok, Session1, {QOS, MsgChannel}} ->
+        {ok, Session1, {_QOS, _MsgChannel}} ->
             Session1;
         {Msg1, Session1, {QOS, MsgChannel}} ->
             channelize_msg(Msg1, Channels, {QOS, MsgChannel}),

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -48,45 +48,20 @@ handle_info({enet, disconnected, remote, _Pid, _When}, State) ->
     logger:info("ENet session ~p disconnected", [IP]),
     cleanup_session(Session),
     {stop, normal, State};
-handle_info(
-    {enet, Channel, {reliable, Msg}},
-    State = #{channels := Channels, session := Session}
-) ->
-    ChannelPid = maps:get(Channel, Channels),
-    S1 =
-        case ow_protocol:decode(Msg, Session) of
-            % Table of possible returns
-            %   ok -> No reply, keep old session
-            %   {ok, Session1} -> No reply, update session
-            %   {Msg1, Session1} -> Reply message, update session (which may
-            %   ==Session)
-            ok ->
-                Session;
-            {ok, Session1} ->
-                Session1;
-            {Msg1, Session1} ->
-                FlatMsg = iolist_to_binary(Msg1),
-                enet:send_reliable(ChannelPid, FlatMsg),
-                Session1
-        end,
+handle_info({enet, Channel, {reliable, Msg}}, State) ->
+    S1 = decode_and_reply(Msg, Channel, {enet, send_reliable}, State),
     {noreply, State#{session := S1}};
-handle_info({enet, _Channel, {unreliable, Seq, Packet}}, State) ->
-    logger:debug("Got an unreliable packet: ~p:~p", [Seq, Packet]),
-    {noreply, State};
-handle_info({enet, _Channel, {unsequenced, Group, Packet}}, State) ->
-    logger:debug("Got a message from another process: ~p:~p", [
-        Group, Packet
-    ]),
-    {noreply, State};
-handle_info({_From, Type, Msg}, State = #{channels := Channels}) when
+handle_info({enet, Channel, {unreliable, _Seq, Msg}}, State) ->
+    S1 = decode_and_reply(Msg, Channel, {enet, send_unreliable}, State),
+    {noreply, State#{session := S1}};
+handle_info({enet, Channel, {unsequenced, _Group, Msg}}, State) ->
+    S1 = decode_and_reply(Msg, Channel, {enet, send_unsequenced}, State),
+    {noreply, State#{session := S1}};
+handle_info({_From, Type, Msg, Options}, State = #{channels := Channels}) when
     Type =:= 'broadcast'; Type =:= 'zone_msg'
 ->
     % Handle a message from another overworld process
-    % TODO: Thread through channel
-    ChannelPID = maps:get(0, Channels),
-    %       selection
-    FlatMsg = iolist_to_binary(Msg),
-    enet:send_reliable(ChannelPID, FlatMsg),
+    channelize_msg(Msg, Channels, Options),
     {noreply, State}.
 
 terminate(_Reason, _State = #{session := Session}) ->
@@ -102,4 +77,53 @@ cleanup_session(Session) ->
             erlang:apply(M, F, [Session]);
         _ ->
             ok
+    end.
+
+channelize_msg(Msg, Channels, {QOS, Channel}) ->
+    % Not sure if it's worth implementing any fall-throughs here, better to
+    % crash early if someone fat-fingers the QOS or channel number rather than
+    % to unexpectedly send reliable,0 messages.
+    ChannelPID = 
+        case Channel of
+            undefined -> 
+                % Default to channel 0 if undefined
+                maps:get(0, Channels);
+            C -> 
+                maps:get(C, Channels)
+        end,
+    FlatMsg = iolist_to_binary(Msg),
+    case QOS of
+        reliable -> 
+            enet:send_reliable(ChannelPID, FlatMsg);
+        unreliable -> 
+            enet:send_unreliable(ChannelPID, FlatMsg);
+        unsequenced -> 
+            enet:send_unsequenced(ChannelPID, FlatMsg);
+        undefined ->
+            % Send a reliable packet if nothing defined
+            enet:send_reliable(ChannelPID, FlatMsg)
+    end.
+
+decode_and_reply(Msg, IncomingChannel, {Mod, Fun}, State) ->
+    #{channels := Channels, session := Session} = State,
+    case ow_protocol:decode(Msg, Session) of
+        % Table of possible returns
+        %   ok -> No reply, keep old session
+        %   {ok, Session1} -> No reply, update session
+        %   {Msg1, Session1} -> Reply message, update session (which may
+        %   ==Session)
+        ok ->
+            Session;
+        {ok, Session1} ->
+            Session1;
+        {Msg1, Session1} ->
+            % Default to sending a reliable message on whatever channel the
+            % original message came in on
+            FlatMsg = iolist_to_binary(Msg1),
+            ChannelPid = maps:get(IncomingChannel, Channels),
+            erlang:apply(Mod, Fun, [ChannelPid, FlatMsg]),
+            Session1;
+        {Msg1, Session1, {QOS, MsgChannel}} ->
+            channelize_msg(Msg1, Channels, {QOS, MsgChannel}),
+            Session1
     end.

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -18,6 +18,12 @@
     start/1
 ]).
 
+-type qos() :: {
+    reliable | unreliable | unsequenced | undefined,
+    non_neg_integer() | undefined
+}.
+-export_type([qos/0]).
+
 start(PeerInfo) ->
     gen_server:start_link(?MODULE, [PeerInfo], []).
 

--- a/src/ow_protocol.erl
+++ b/src/ow_protocol.erl
@@ -96,7 +96,9 @@ register(Module) ->
 -spec decode(binary(), ow_session:session()) ->
     ok
     | {ok, ow_session:session()}
-    | {binary(), ow_session:session()}.
+    | {binary(), ow_session:session()}
+    | {ok, ow_session:session(), ow_enet:qos()}
+    | {binary(), ow_session:session(), ow_enet:qos()}.
 decode(Message, Session) ->
     gen_server:call(?MODULE, {decode, Message, Session}).
 

--- a/src/ow_rpc.erl
+++ b/src/ow_rpc.erl
@@ -7,6 +7,8 @@
     c2s_proto/1,
     s2c_call/1,
     encoder/1,
+    qos/1,
+    channel/1,
     find_call/2,
     find_handler/2
 ]).
@@ -16,7 +18,10 @@
     c2s_handler => mfa() | undefined,
     c2s_proto => atom() | undefined,
     s2c_call => atom() | undefined,
-    encoder := atom() | undefined
+    encoder := atom() | undefined,
+    % Only usable by ENet
+    qos => reliable | unreliable | unsequenced | undefined,
+    channel => non_neg_integer() | undefined
 }.
 -export_type([rpc/0]).
 
@@ -46,6 +51,14 @@ s2c_call(Map) ->
 -spec encoder(map()) -> atom() | undefined.
 encoder(Map) ->
     maps:get(encoder, Map, undefined).
+
+-spec qos(map()) -> atom() | undefined.
+qos(Map) ->
+    maps:get(qos, Map, undefined).
+
+-spec channel(map()) -> non_neg_integer() | undefined.
+channel(Map) ->
+    maps:get(channel, Map, undefined).
 
 -spec find_call(atom(), [rpc(), ...]) -> rpc() | #{}.
 find_call(Msg, [H | L]) ->

--- a/src/ow_session.erl
+++ b/src/ow_session.erl
@@ -87,31 +87,43 @@ rpc_info() ->
     [
         #{
             opcode => ?VERSION,
-            c2s_handler => {?MODULE, version, 1}
+            c2s_handler => {?MODULE, version, 1},
+            qos => reliable,
+            channel => 0
         },
         #{
             opcode => ?SESSION_ID_REQ,
-            c2s_handler => {?MODULE, session_id_req, 2}
+            c2s_handler => {?MODULE, session_id_req, 2},
+            qos => reliable,
+            channel => 0
         },
         #{
             opcode => ?SESSION_ID,
             s2c_call => session_id,
-            encoder => overworld_pb
+            encoder => overworld_pb,
+            qos => reliable,
+            channel => 0
         },
         #{
             opcode => ?SESSION_PING,
             c2s_handler => {?MODULE, session_ping, 2},
-            encoder => overworld_pb
+            encoder => overworld_pb,
+            qos => reliable,
+            channel => 0
         },
         #{
             opcode => ?SESSION_PONG,
             s2c_call => session_pong,
-            encoder => overworld_pb
+            encoder => overworld_pb,
+            qos => reliable,
+            channel => 0
         },
         #{
             opcode => ?SESSION_LOG,
             s2c_call => session_log,
-            encoder => overworld_pb
+            encoder => overworld_pb,
+            qos => reliable,
+            channel => 0
         }
     ].
 

--- a/src/ow_session.erl
+++ b/src/ow_session.erl
@@ -13,7 +13,7 @@
 
 -export([
     encode_log/1,
-    broadcast/1,
+    broadcast/2,
     multicast/2,
     new/0,
     set_id/2,
@@ -203,14 +203,14 @@ encode_log_test() ->
 %% @doc Broadcast a message to all clients. Must already be serialized.
 %% @end
 %%----------------------------------------------------------------------------
--spec broadcast(msg()) -> ok.
-broadcast(EncodedMsg) ->
+-spec broadcast(msg(), {atom(), non_neg_integer() | undefined}) -> ok.
+broadcast(EncodedMsg, Options) ->
     case gproc:lookup_pids({p, l, client_session}) of
         [] ->
             ok;
         _ ->
             gproc:send({p, l, client_session}, {
-                self(), broadcast, EncodedMsg
+                self(), broadcast, EncodedMsg, Options
             })
     end,
     ok.

--- a/src/ow_websocket.erl
+++ b/src/ow_websocket.erl
@@ -81,6 +81,9 @@ websocket_handle({binary, Msg}, Session) ->
         {ok, Session1} ->
             {ok, Session1};
         {Msg1, Session1} ->
+            {reply, {binary, Msg1}, Session1};
+        {Msg1, Session1, _Options} ->
+            % Options only for ENet for the moment
             {reply, {binary, Msg1}, Session1}
     end;
 websocket_handle(Frame, State) ->
@@ -92,7 +95,7 @@ websocket_handle(Frame, State) ->
 %%      process comes into this handler process.
 %% @end
 %%--------------------------------------------------------------------------
-websocket_info({_Pid, Type, Msg}, Session) when
+websocket_info({_Pid, Type, Msg, _Options}, Session) when
     Type =:= 'broadcast'; Type =:= 'zone_msg'
 ->
     {reply, {binary, Msg}, Session};

--- a/src/ow_websocket.erl
+++ b/src/ow_websocket.erl
@@ -82,6 +82,9 @@ websocket_handle({binary, Msg}, Session) ->
             {ok, Session1};
         {Msg1, Session1} ->
             {reply, {binary, Msg1}, Session1};
+        {ok, Session1, _Options} ->
+            % Options only for ENet for the moment
+            {ok, Session1};
         {Msg1, Session1, _Options} ->
             % Options only for ENet for the moment
             {reply, {binary, Msg1}, Session1}

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -69,6 +69,7 @@
     require_auth :: boolean(),
     rpcs :: ow_rpcs:callbacks()
 }).
+-type state() :: #state{}.
 
 -define(DEFAULT_CONFIG, #{
     % milliseconds between ticks
@@ -327,11 +328,12 @@ initialize_state(CbMod, CbData, Config = #{tick_ms := TickMs}) ->
 handle_call(?TAG_I({Action, Msg, Session}), _From, St0) ->
     % where Action = join or part.
     {Session1, St1} = maybe_auth_do(Action, Msg, Session, St0),
-    {reply, {ok, Session1}, St1};
+    % Get channel and QOS information
+    {reply, {ok, Session1, enet_msg_opts(Action, St1)}, St1};
 handle_call(?TAG_I({Action, Session}), _From, St0) ->
     % where Action = join or part.
     {Session1, St1} = maybe_auth_do(Action, Session, St0),
-    {reply, {ok, Session1}, St1};
+    {reply, {ok, Session1, enet_msg_opts(Action, St1)}, St1};
 handle_call(?TAG_I({who}), _From, St0) ->
     Players = ow_player_reg:list(self()),
     IDs = [ow_player_reg:get_id(P) || P <- Players],
@@ -350,7 +352,7 @@ handle_call(?TAG_I({status}), _From, St0) ->
     {reply, StatusMsg, St1};
 handle_call(?TAG_I({rpc, Type, Msg, Session}), _From, St0) ->
     {Session1, St1} = maybe_auth_rpc(Type, Msg, Session, St0),
-    {reply, {ok, Session1}, St1};
+    {reply, {ok, Session1, enet_msg_opts(Type, St1)}, St1};
 handle_call(_Call, _From, St0) ->
     {reply, ok, St0}.
 
@@ -441,9 +443,10 @@ notify_players(MsgType, Msg, RPCs, Players) ->
                         EMod = ow_rpc:encoder(RPC),
                         OpCode = ow_rpc:opcode(RPC),
                         EncodedMsg = EMod:encode_msg(Msg, MsgType),
-                        % TODO: to which process is self() referring?
-                        Pid !
-                            {self(), zone_msg, [<<OpCode:16>>, EncodedMsg]}
+                        Channel = ow_rpc:channel(RPC),
+                        QOS = ow_rpc:qos(RPC),
+                        Pid ! 
+                            {self(), zone_msg, [<<OpCode:16>>, EncodedMsg], {QOS, Channel}}
                 end
         end
     end,
@@ -611,3 +614,11 @@ update_player(PlayerInfo, ID) ->
     P = ow_player_reg:get(ID),
     P1 = ow_player_reg:set_info(PlayerInfo, P),
     ow_player_reg:update(P1).
+
+-spec enet_msg_opts(atom, state()) -> {atom(), non_neg_integer()|undefined}.
+enet_msg_opts(Action, State) ->
+    RPCs = State#state.rpcs,
+    RPC = ow_rpc:find_call(Action, RPCs),
+    Channel = ow_rpc:channel(RPC),
+    QOS = ow_rpc:qos(RPC),
+    {QOS, Channel}.

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -445,8 +445,13 @@ notify_players(MsgType, Msg, RPCs, Players) ->
                         EncodedMsg = EMod:encode_msg(Msg, MsgType),
                         Channel = ow_rpc:channel(RPC),
                         QOS = ow_rpc:qos(RPC),
-                        Pid ! 
-                            {self(), zone_msg, [<<OpCode:16>>, EncodedMsg], {QOS, Channel}}
+                        Pid !
+                            {
+                                self(),
+                                zone_msg,
+                                [<<OpCode:16>>, EncodedMsg],
+                                {QOS, Channel}
+                            }
                 end
         end
     end,
@@ -615,7 +620,8 @@ update_player(PlayerInfo, ID) ->
     P1 = ow_player_reg:set_info(PlayerInfo, P),
     ow_player_reg:update(P1).
 
--spec enet_msg_opts(atom, state()) -> {atom(), non_neg_integer()|undefined}.
+-spec enet_msg_opts(atom, state()) ->
+    {atom(), non_neg_integer() | undefined}.
 enet_msg_opts(Action, State) ->
     RPCs = State#state.rpcs,
     RPC = ow_rpc:find_call(Action, RPCs),


### PR DESCRIPTION
This PR threads ENet-style channels and message types through Overworld, which I'm broadly calling quality of service (QOS). 

You can now specify the qos and channels in your rpc_info/0 callback like so:
```erlang
        #{
            opcode => ?KS_ZONE_JOIN,
            c2s_handler => {?MODULE, join, 2},
            s2c_call => join,
            encoder => ks_pb,
            qos => reliable,
            channel => 0
        },
```

The WebSocket integration should safely ignore this feature. 