### PR TITLE
Fix startup, change default ports

### DIFF
--- a/src/ow_app.erl
+++ b/src/ow_app.erl
@@ -10,7 +10,7 @@
 -define(PEER_LIMIT, "64").
 -define(CHANNEL_LIMIT, "4").
 -define(ENET_PORT, "4483").
--define(WS_PORT, "4433"). 
+-define(WS_PORT, "4433").
 
 -spec make_config(map()) -> map().
 make_config(StartArgs) ->
@@ -29,6 +29,8 @@ make_config(StartArgs) ->
     maps:merge(Cfg, StartArgs).
 
 -spec start(application:start_type(), map()) -> supervisor:startlink_ret().
+start(StartType, []) -> 
+    start(StartType, #{});
 start(_StartType, StartArgs) ->
     #{
         ws_port := WsPort,

--- a/src/ow_app.erl
+++ b/src/ow_app.erl
@@ -9,8 +9,8 @@
 
 -define(PEER_LIMIT, "64").
 -define(CHANNEL_LIMIT, "4").
--define(ENET_PORT, "4484").
--define(WS_PORT, "4434").
+-define(ENET_PORT, "4483").
+-define(WS_PORT, "4433"). 
 
 -spec make_config(map()) -> map().
 make_config(StartArgs) ->


### PR DESCRIPTION
This fixes the case where the default arguments of application start are usually []. It just discards that and makes it an empty map instead. 

Also shifts the default ports down by 1, cosmetic change.
I would like 4434 and 4484 to be the TLS and DTLS ports, eventually.