### PR TITLE
Enet cleanup

### DIFF
--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -49,10 +49,9 @@ handle_call({call, Msg}, _From, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 handle_info({enet, disconnected, remote, _Pid, _When}, State) ->
-    #{session := Session, ip := RawIP} = State,
+    #{ip := RawIP} = State,
     IP = inet:ntoa(RawIP),
     logger:notice("ENet session ~p disconnected", [IP]),
-    cleanup_session(Session),
     {stop, normal, State};
 handle_info({enet, Channel, {reliable, Msg}}, State) ->
     S1 = decode_and_reply(Msg, Channel, {enet, send_reliable}, State),
@@ -73,7 +72,7 @@ handle_info(
     {noreply, State}.
 
 terminate(_Reason, _State = #{session := Session}) ->
-    % We caught an error, call the cleanup trigger
+    % We've caught an error or otherwise asked to stop, clean up the session
     cleanup_session(Session),
     ok.
 

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -31,7 +31,7 @@ start(PeerInfo) ->
 
 init([PeerInfo]) ->
     IP = inet:ntoa(maps:get(ip, PeerInfo)),
-    logger:info("New ENet connection from ~p", [IP]),
+    logger:notice("Starting ENet session for ~p", [IP]),
     ID = erlang:unique_integer(),
     S1 = ow_session:set_id(ID, ow_session:new()),
     S2 = ow_session:set_pid(self(), S1),
@@ -51,7 +51,7 @@ handle_cast(_Msg, State) ->
 handle_info({enet, disconnected, remote, _Pid, _When}, State) ->
     #{ip := RawIP} = State,
     IP = inet:ntoa(RawIP),
-    logger:notice("ENet session ~p disconnected", [IP]),
+    logger:notice("Ending ENet session for ~p", [IP]),
     {stop, normal, State};
 handle_info({enet, Channel, {reliable, Msg}}, State) ->
     S1 = decode_and_reply(Msg, Channel, {enet, send_reliable}, State),


### PR DESCRIPTION
Cleanup code was getting called twice since `terminate` is always called. Fixed and updated the log messages a bit.