### PR TITLE
Proc returns the system called as well as the result

### DIFF
--- a/src/ow_ecs.erl
+++ b/src/ow_ecs.erl
@@ -208,7 +208,7 @@ proc(World, Data) ->
                 Fun2 ->
                     Fun2(World, Data)
             end,
-        [Result | Acc]
+        [{Sys, Result} | Acc]
     end,
     lists:foldl(Fun, [], Systems).
 

--- a/src/ow_ecs2.erl
+++ b/src/ow_ecs2.erl
@@ -287,6 +287,6 @@ proc(Data, World) ->
                 Fun2 ->
                     Fun2(Data, World)
             end,
-        [Result | Acc]
+        [{Sys, Result} | Acc]
     end,
     lists:foldl(Fun, [], Systems).


### PR DESCRIPTION
This fixes the results of ECS proc'ing so they're a bit more useful for stateless systems. 