### PR TITLE
Add WebSocket TLS

### DIFF
--- a/src/ow_app.erl
+++ b/src/ow_app.erl
@@ -61,7 +61,7 @@ start(_StartType, StartArgs) ->
 stop(_State) ->
     ok.
 
--spec start_http(integer(), map()) -> ok.
+-spec start_http(integer(), cowboy_router:dispatch_rules()) -> ok.
 start_http(Port, Dispatch) ->
     {ok, _} = cowboy:start_clear(
         http,
@@ -74,7 +74,9 @@ start_http(Port, Dispatch) ->
     ),
     ok.
 
--spec start_https(integer(), string(), string(), map()) -> ok.
+-spec start_https(
+    integer(), string(), string(), cowboy_router:dispatch_rules()
+) -> ok.
 start_https(Port, CertFile, KeyFile, Dispatch) ->
     case CertFile of
         false ->

--- a/src/ow_app.erl
+++ b/src/ow_app.erl
@@ -11,6 +11,102 @@
 -define(CHANNEL_LIMIT, "4").
 -define(ENET_PORT, "4483").
 -define(WS_PORT, "4433").
+-define(WSS_PORT, "4434").
+-define(OW_PREFIX, 100).
+
+-spec start(application:start_type(), map()) -> supervisor:startlink_ret().
+start(StartType, []) ->
+    start(StartType, #{});
+start(_StartType, StartArgs) ->
+    #{
+        ws_port := WsPort,
+        wss_port := WssPort,
+        enet_port := EnetPort,
+        peer_limit := PeerLimit,
+        channel_limit := ChannelLimit
+    } = make_config(StartArgs),
+    Dispatch = cowboy_router:compile([
+        {'_', [
+            {"/ws", ow_websocket, []},
+            {"/client/download", ow_dl_handler, []},
+            {"/client/manifest", ow_dl_manifest, []}
+        ]}
+    ]),
+    % Start Cowboy for Websocket connections
+    start_http(WsPort, Dispatch),
+    CertFile = os:getenv("OW_TLS_CERT"),
+    KeyFile = os:getenv("OW_TLS_KEY"),
+    start_https(WssPort, CertFile, KeyFile, Dispatch),
+    % Start ENet for UDP connections
+    Options = [
+        {peer_limit, PeerLimit},
+        {channel_limit, ChannelLimit},
+        {compression_mode, zlib}
+    ],
+    Handler = {ow_enet, start, []},
+    enet:start_host(EnetPort, Handler, Options),
+    % Start the OW supervisor
+    SuperLink = ow_sup:start_link(),
+    % Now register the initial application and modules before returning
+    Application = #{
+        app => overworld,
+        prefix => ?OW_PREFIX,
+        router => ow_msg,
+        modules => [ow_account, ow_session, ow_beacon]
+    },
+    ow_protocol:register(Application),
+    SuperLink.
+
+-spec stop(term()) -> ok.
+stop(_State) ->
+    ok.
+
+-spec start_http(integer(), map()) -> ok.
+start_http(Port, Dispatch) ->
+    {ok, _} = cowboy:start_clear(
+        http,
+        [
+            {port, Port},
+            % turn off TCP_NODELAY for better game perf
+            {nodelay, true}
+        ],
+        #{env => #{dispatch => Dispatch}}
+    ),
+    ok.
+
+-spec start_https(integer(), string(), string(), map()) -> ok.
+start_https(Port, CertFile, KeyFile, Dispatch) ->
+    case CertFile of
+        false ->
+            logger:warning("Not starting HTTPS, no certfile provided");
+        _ ->
+            case KeyFile of
+                false ->
+                    logger:warning(
+                        "Not starting HTTPS, no keyfile provided"
+                    );
+                _ ->
+                    Result = cowboy:start_tls(
+                        https,
+                        [
+                            {port, Port},
+                            % turn off TCP_NODELAY for better game perf
+                            {nodelay, true},
+                            {certfile, CertFile},
+                            {keyfile, KeyFile}
+                        ],
+                        #{env => #{dispatch => Dispatch}}
+                    ),
+                    case Result of
+                        {ok, _} ->
+                            ok;
+                        Error ->
+                            logger:error("Failed to start HTTPS: ~p", [
+                                Error
+                            ])
+                    end
+            end
+    end.
 
 -spec make_config(map()) -> map().
 make_config(StartArgs) ->
@@ -24,57 +120,8 @@ make_config(StartArgs) ->
         enet_port =>
             list_to_integer(os:getenv("OW_ENET_PORT", ?ENET_PORT)),
         ws_port =>
-            list_to_integer(os:getenv("OW_WS_PORT", ?WS_PORT))
+            list_to_integer(os:getenv("OW_WS_PORT", ?WS_PORT)),
+        wss_port =>
+            list_to_integer(os:getenv("OW_WSS_PORT", ?WSS_PORT))
     },
     maps:merge(Cfg, StartArgs).
-
--spec start(application:start_type(), map()) -> supervisor:startlink_ret().
-start(StartType, []) -> 
-    start(StartType, #{});
-start(_StartType, StartArgs) ->
-    #{
-        ws_port := WsPort,
-        enet_port := EnetPort,
-        peer_limit := PeerLimit,
-        channel_limit := ChannelLimit
-    } = make_config(StartArgs),
-    Dispatch = cowboy_router:compile([
-        {'_', [
-            {"/ws", ow_websocket, []},
-            {"/client/download", ow_dl_handler, []},
-            {"/client/manifest", ow_dl_manifest, []}
-        ]}
-    ]),
-    % Start WebSocket/CowBoy
-    {ok, _} = cowboy:start_clear(
-        http,
-        [
-            {port, WsPort},
-            % turn off TCP_NODELAY for better game perf
-            {nodelay, true}
-        ],
-        #{env => #{dispatch => Dispatch}}
-    ),
-    % Start ENet
-    Options = [
-        {peer_limit, PeerLimit},
-        {channel_limit, ChannelLimit},
-        {compression_mode, zlib}
-    ],
-    Handler = {ow_enet, start, []},
-    enet:start_host(EnetPort, Handler, Options),
-    % Start the OW supervisor
-    SuperLink = ow_sup:start_link(),
-    % Now register the initial application and modules before returning
-    Application = #{
-        app => overworld,
-        prefix => 100,
-        router => ow_msg,
-        modules => [ow_account, ow_session, ow_beacon]
-    },
-    ow_protocol:register(Application),
-    SuperLink.
-
--spec stop(term()) -> ok.
-stop(_State) ->
-    ok.


### PR DESCRIPTION
This PR adds TLS support via Cowboy HTTPS. (Perhaps a later pass could replace the big nested `case` with a `maybe` operator.)

To use TLS, you will need to export 2 vars into your environment:
`OW_TLS_CERT` and `OW_TLS_KEY` which refer to the certificate and private key files respectively. This is necessary for embedding on platforms like Itch.io and is good practice overall. 

This PR moves some magic numbers (the OW prefix) to the top-level defines as well. 