### PR TITLE
OW Zone: simplification, disconnect, reconnect

### DIFF
--- a/priv/proto/overworld.proto
+++ b/priv/proto/overworld.proto
@@ -60,8 +60,6 @@ message session_log {
 
 // server -> client
 message session_id_req {
-    // totally unnecessary it makes the client generation simpler
-    optional uint32 version = 1;
 }
 
 // server -> client

--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -113,6 +113,13 @@ func enet_connect(ip: String, port: int):
 	mode = transport_mode.ENET
 	# Set mode to ZLIB
 	_enet_peer.host.compress(ENetConnection.COMPRESS_ZLIB)
+    
+func enet_disconnect():
+	for peer in _enet_peer.host.get_peers():
+		print("Peer: " + str(peer))
+		peer.peer_disconnect()
+	_enet_peer.close()
+	mode = null
 
 # Take the host and whether or not its a TLS conncetion
 func ws_connect(address: String, port: int = 4433):

--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -9,7 +9,7 @@ var _ws_peer = WebSocketPeer.new()
 var _ws_connected = false
 
 @export var session: Dictionary
-@export var rejoin_token: Bytes
+@export var rejoin_token: PackedByteArray
 
 var debug = false
 

--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -114,13 +114,14 @@ func enet_connect(ip: String, port: int):
 	mode = transport_mode.ENET
 	# Set mode to ZLIB
 	_enet_peer.host.compress(ENetConnection.COMPRESS_ZLIB)
-    
+	
 func enet_disconnect():
 	for peer in _enet_peer.host.get_peers():
 		print("Peer: " + str(peer))
 		peer.peer_disconnect()
 	_enet_peer.close()
 	mode = null
+	emit_signal("server_disconnected")
 
 # Take the host and whether or not its a TLS conncetion
 func ws_connect(address: String, port: int = 4433):
@@ -128,15 +129,24 @@ func ws_connect(address: String, port: int = 4433):
 	print("[INFO] Connecting via WebSocket to ", url)
 	_websocket_connect(url)
 	
+func ws_disconnect():
+	_websocket_close()
+	mode = null
+	
 func wss_connect(address: String, port: int = 4434):
 	var url = "wss://" + address + ":" + str(port) + "/ws"
 	print("[INFO] Connecting via WebSocketSecure to ", url)
 	_websocket_connect(url)
 
+func wss_disconnect():
+	_websocket_close()
+
 func _websocket_connect(url):
 	_ws_peer.connect_to_url(url)
 	mode = transport_mode.WEBSOCKET
-	emit_signal("server_connected")
+
+func _websocket_close():
+	_ws_peer.close()
 
 func _send_message(payload, opcode, qos, channel):
 	# Create a new packet starting with opcode, append the message if it exists,
@@ -183,6 +193,7 @@ func _process(_delta):
 			# Keep polling to achieve proper close.
 			pass
 		elif state == WebSocketPeer.STATE_CLOSED:
+			_ws_connected = false
 			emit_signal("server_disconnected")
 	elif mode == transport_mode.ENET:
 		var p = _enet_peer.host.service() # Check for packets

--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -9,6 +9,7 @@ var _ws_peer = WebSocketPeer.new()
 var _ws_connected = false
 
 @export var session: Dictionary
+@export var rejoin_token: Bytes
 
 var debug = false
 

--- a/src/ow_sup.erl
+++ b/src/ow_sup.erl
@@ -32,6 +32,10 @@ init([]) ->
             start => {ow_player_reg, start_link, []}
         },
         #{
+            id => ow_token_serv,
+            start => {ow_token_serv, start_link, []}
+        },
+        #{
             id => ow_beacon,
             start => {ow_beacon, start, []}
         }

--- a/src/ow_token_serv.erl
+++ b/src/ow_token_serv.erl
@@ -1,0 +1,69 @@
+-module(ow_token_serv).
+-behaviour(gen_server).
+
+-export([
+    start_link/0,
+    new/1,
+    exchange/2
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-define(MAX_BYTES, 16).
+
+-record(state, {
+    tokens = []
+}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+new(ID) ->
+    gen_server:call(?MODULE, {new, ID}).
+exchange(ID, Token) ->
+    gen_server:call(?MODULE, {exchange, ID, Token}).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call({new, ID}, _From, #state{tokens = Tokens} = State) ->
+    Token = create_token(),
+    Tokens1 = [{ID, Token} | Tokens],
+    {reply, Token, State#state{tokens = Tokens1}};
+handle_call({exchange, ID, Token}, _From, #state{tokens = Tokens} = State) ->
+    case lists:keyfind(ID, 1, Tokens) of
+        false ->
+            {reply, false, State};
+        {ID, Token} ->
+            % Token matches via pattern matching, give the user a new token
+            NewToken = create_token(),
+            Tokens1 = lists:keyreplace(ID, 1, Tokens, {ID, NewToken}),
+            {reply, NewToken, State#state{tokens = Tokens1}};
+        {ID, _} ->
+            {reply, denied, State}
+    end;
+handle_call(_, _, State) ->
+    {reply, ignored, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% Internal functions
+create_token() ->
+    crypto:strong_rand_bytes(?MAX_BYTES).

--- a/src/ow_token_serv.erl
+++ b/src/ow_token_serv.erl
@@ -4,7 +4,7 @@
 -export([
     start_link/0,
     new/1,
-    exchange/2
+    exchange/1
 ]).
 
 %% gen_server callbacks
@@ -27,8 +27,8 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 new(ID) ->
     gen_server:call(?MODULE, {new, ID}).
-exchange(ID, Token) ->
-    gen_server:call(?MODULE, {exchange, ID, Token}).
+exchange(Token) ->
+    gen_server:call(?MODULE, {exchange, Token}).
 
 init([]) ->
     {ok, #state{}}.
@@ -37,16 +37,16 @@ handle_call({new, ID}, _From, #state{tokens = Tokens} = State) ->
     Token = create_token(),
     Tokens1 = [{ID, Token} | Tokens],
     {reply, Token, State#state{tokens = Tokens1}};
-handle_call({exchange, ID, Token}, _From, #state{tokens = Tokens} = State) ->
-    case lists:keyfind(ID, 1, Tokens) of
+handle_call({exchange, Token}, _From, #state{tokens = Tokens} = State) ->
+    case lists:keyfind(Token, 2, Tokens) of
         false ->
             {reply, false, State};
         {ID, Token} ->
             % Token matches via pattern matching, give the user a new token
             NewToken = create_token(),
             Tokens1 = lists:keyreplace(ID, 1, Tokens, {ID, NewToken}),
-            {reply, NewToken, State#state{tokens = Tokens1}};
-        {ID, _} ->
+            {reply, {ID, NewToken}, State#state{tokens = Tokens1}};
+        {_, _} ->
             {reply, denied, State}
     end;
 handle_call(_, _, State) ->

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -348,12 +348,12 @@ handle_cast(_Cast, St0) ->
 handle_info(?TAG_I(tick), St0) ->
     St1 = tick(St0),
     {noreply, St1};
-handle_info(Msg, #{cb_mod := CbMod} = St0) -> 
+handle_info(Msg, #{cb_mod := CbMod} = St0) ->
     St1 =
         case erlang:function_exported(CbMod, handle_info, 2) of
-            false -> 
+            false ->
                 St0;
-            true -> 
+            true ->
                 info(Msg, St0)
         end,
     {noreply, St1}.
@@ -496,7 +496,7 @@ add_and_notify(Session0, St0, Status, CbMod, CbData1, Notify) ->
     St1 = St0#state{cb_data = CbData1},
     handle_notify(Notify, St1),
     % Set the player's termination callback
-    Session2 = 
+    Session2 =
         ow_session:set_termination_callback(
             {CbMod, disconnect, 1}, Session1
         ),

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -248,7 +248,7 @@ part(ServerRef, Msg, Session) ->
 disconnect(ServerRef, Session) ->
     gen_server:call(ServerRef, ?TAG_I({disconnect, Session})).
 
--spec reconnect(server_ref(), session()) -> {ok, session()}.
+-spec reconnect(server_ref(), session()) -> ok.
 reconnect(ServerRef, Session) ->
     gen_server:cast(ServerRef, ?TAG_I({reconnect, Session})).
 

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -67,7 +67,7 @@
     cb_data :: term(),
     tick_ms :: pos_integer(),
     require_auth :: boolean(),
-    disconnects :: [session()],
+    disconnects = [] :: [session()],
     dc_timeout_ms :: pos_integer()
 }).
 %-type state() :: #state{}.
@@ -361,7 +361,7 @@ handle_info(?TAG_I(tick), St0) ->
     St1 = tick(St0),
     St2 = timeout_disconnects(St1),
     {noreply, St2};
-handle_info(Msg, #{cb_mod := CbMod} = St0) ->
+handle_info(Msg, #state{cb_mod = CbMod} = St0) ->
     St1 =
         case erlang:function_exported(CbMod, handle_info, 2) of
             false ->
@@ -398,8 +398,8 @@ timeout_disconnects(
                     Disconnects1 = lists:delete(P, Disconnects),
                     % The callback part handler MUST accept an empty message as a result
                     {_Session1, St1} = actually_do(part, #{}, Session, St0),
-                    St1#{
-                        disconnects => Disconnects1
+                    St1#state{
+                        disconnects = Disconnects1
                     };
                 false ->
                     St0


### PR DESCRIPTION
This PR modifies the functionality of the `ow_zone` behaviour in the following ways:
* `part/1` and `join/1` removed. Overworld can handle protobuf messages with empty fields.
* `part/2` and `join/2` are now required callbacks.
* new functionality to track and remove entities that have disconnected. 
   - the ow_zone server will call `<callback_module>:part/2` with empty map as the message. consequently, modules that implement the ow_zone behavior will be required to the implement `handle_part(#{}, Session, State)` callback.
* new optional callback `handle_disconnect/2` for immediate notification of client disconnections.  
* new `enet_disconnect()`, `ws_disconnect()` and `wss_disconncet()` functions added to `libow4.gd`. when closed, an `server_disconnected` signal will be emitted by the library
* new token exchange server (`ow_token_server.erl`) to facilitate reconnecting clients. 
   - a client will be issued a reconnect token on first connection, and must present the reconnect token if they wish to be reconnected to a previous session before it times out