### PR TITLE
Fixups for gdscript generation, fix message crash

### DIFF
--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -32,8 +32,7 @@ start(PeerInfo) ->
 init([PeerInfo]) ->
     IP = inet:ntoa(maps:get(ip, PeerInfo)),
     logger:notice("Starting ENet session for ~p", [IP]),
-    ID = erlang:unique_integer(),
-    S1 = ow_session:set_id(ID, ow_session:new()),
+    S1 = ow_session:new(),
     S2 = ow_session:set_pid(self(), S1),
     S3 = ow_session:set_serializer(protobuf, S2),
     % Register this proces with gproc

--- a/src/ow_session.erl
+++ b/src/ow_session.erl
@@ -168,7 +168,7 @@ multicast(EncodedMsg, SessionIDs) ->
 %%----------------------------------------------------------------------------
 -spec new() -> session().
 new() ->
-    #session{id = erlang:unique_integer()}.
+    #session{id = erlang:unique_integer([positive])}.
 
 %%----------------------------------------------------------------------------
 %% @doc Set the session ID


### PR DESCRIPTION
Two changes
1. Fix up a crash when the Player's (Erlang) pid is sent a message after they've left the zone. At least in the case of disconnects, the safe thing to do here is just ignore the message
2. Fix the GDScript bindings to behave better when fields are optional. Depends on if this PR is suitable for merging upstream: https://github.com/oniksan/godobuf/pull/42 