### PR TITLE
Fix failing proto

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: erlang:27
+      image: erlang:26
 
     steps:
     - uses: actions/checkout@v3

--- a/priv/proto/overworld.proto
+++ b/priv/proto/overworld.proto
@@ -8,17 +8,15 @@ package overworld;
 /////////////////////////////////////////////////////////
 message overworld {
     oneof msg {
-        gen_response   gen_response   = 1;
-        account_new    account_new    = 2;
-        account_login  account_login  = 3;
-        session_log    session_log    = 4;
-        session_beacon session_beacon = 5;
-        session_ping   session_ping   = 6;
-        session_pong   session_pong   = 7;
-        session_new    session_new    = 8;
-        session_id     session_id     = 9;
-        session_id_req session_id_req = 10;
-        hull_cmd       hull_cmd       = 11;
+        account_new    account_new    = 1;
+        account_login  account_login  = 2;
+        session_log    session_log    = 3;
+        session_beacon session_beacon = 4;
+        session_ping   session_ping   = 5;
+        session_pong   session_pong   = 6;
+        session_new    session_new    = 7;
+        session_id     session_id     = 8;
+        session_id_req session_id_req = 9;
     }
 }
 
@@ -88,13 +86,4 @@ message session_new {
     // initialize a sesison and send to the client. 
     required int64 id = 1; // public
     required bytes reconnect_token = 2; // secret
-}
-
-/////////////////////////////////////////////////////////
-// Command-oriented Interface                          //
-/////////////////////////////////////////////////////////
-
-// text-oriented protocol
-message hull_cmd { 
-    required string text = 2;
 }

--- a/priv/proto/overworld.proto
+++ b/priv/proto/overworld.proto
@@ -8,45 +8,16 @@ package overworld;
 /////////////////////////////////////////////////////////
 message overworld {
     oneof msg {
-        account_new    account_new    = 1;
-        account_login  account_login  = 2;
-        session_log    session_log    = 3;
-        session_beacon session_beacon = 4;
-        session_ping   session_ping   = 5;
-        session_pong   session_pong   = 6;
-        session_new    session_new    = 7;
-        session_id     session_id     = 8;
-        session_id_req session_id_req = 9;
+        session_log    session_log    = 1;
+        session_beacon session_beacon = 2;
+        session_ping   session_ping   = 3;
+        session_pong   session_pong   = 4;
+        session_new    session_new    = 5;
+        session_id     session_id     = 6;
+        session_id_req session_id_req = 7;
     }
 }
 
-
-/////////////////////////////////////////////////////////
-// General messages                                    //
-/////////////////////////////////////////////////////////
-
-message gen_response {
-	enum status {
-		OK = 0;
-		ERROR = 1;
-	}
-	required status status = 1;
-	optional string msg = 2;
-}
-
-/////////////////////////////////////////////////////////
-// Account Messages                                    //
-/////////////////////////////////////////////////////////
-
-message account_new {
-	required string email = 1;
-	required string password = 2;
-}
-
-message account_login {
-	required string email = 1;
-	required string password = 2;
-}
 
 /////////////////////////////////////////////////////////
 // Session Messages                                    //

--- a/src/ow_app.erl
+++ b/src/ow_app.erl
@@ -52,7 +52,7 @@ start(_StartType, StartArgs) ->
         app => overworld,
         prefix => ?OW_PREFIX,
         router => ow_msg,
-        modules => [ow_account, ow_session, ow_beacon]
+        modules => [ow_session, ow_beacon]
     },
     ow_protocol:register(Application),
     SuperLink.

--- a/src/ow_protocol.erl
+++ b/src/ow_protocol.erl
@@ -23,9 +23,7 @@
     rpc/2,
     rpcs/1,
     route/2,
-    router/1,
-    response/1,
-    response/2
+    router/1
 ]).
 
 % gen_server callbacks
@@ -72,38 +70,6 @@ stop() ->
     {reply, ok | {error, atom()}, map()}.
 register(App) ->
     gen_server:call(?MODULE, {register, App}).
-
-%%-------------------------------------------------------------------------
-%% @doc Encode a general response
-%% @end
-%%-------------------------------------------------------------------------
--spec response(ok | error) -> binary().
-response(ok) ->
-    ow_msg:encode(#{status => 'OK'}, gen_response);
-response(error) ->
-    ow_msg:encode(#{status => 'ERROR'}, gen_response).
-
-%%-------------------------------------------------------------------------
-%% @doc Encode a general response with reasoning
-%% @end
-%%-------------------------------------------------------------------------
--spec response(ok | error, string()) -> binary().
-response(ok, Msg) ->
-    ow_msg:encode(
-        #{
-            status => 'OK',
-            msg => Msg
-        },
-        gen_response
-    );
-response(error, Msg) ->
-    ow_msg:encode(
-        #{
-            status => 'ERROR',
-            msg => Msg
-        },
-        gen_response
-    ).
 
 %%-------------------------------------------------------------------------
 %% @doc Get all apps registered with the server, including prefix and


### PR DESCRIPTION
the protobuf file had some old cruft that was not parsing in other protobuf implementations, namely `gen_response` which I haven't used in a while. also removed account messages that are no longer used. 

thanks to @alkielizard for finding the issue.
