### PR TITLE
Session fixups

### DIFF
--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -100,7 +100,7 @@ handle_info(_, PeerInfo) ->
 %% @end
 %%---------------------------------------------------------------------------
 -spec terminate(any(), peerinfo()) -> ok.
-terminate(_Reason, #{ session_id := SessionID }) ->
+terminate(_Reason, #{session_id := SessionID}) ->
     % We've caught an error or otherwise asked to stop, clean up the session
     case ow_session:disconnect_callback(SessionID) of
         {Module, Fun, Args} ->

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -16,6 +16,7 @@
     code_change/3
 ]).
 
+-type peerinfo() :: map().
 -type qos() :: {
     reliable | unreliable | unsequenced | undefined,
     non_neg_integer() | undefined
@@ -42,7 +43,7 @@ start(PeerInfo) ->
 %% @doc Handler is initialized for any new connection and logs the foreign IP
 %% @end
 %%---------------------------------------------------------------------------
--spec init([map()]) -> {ok, map()}.
+-spec init([peerinfo()]) -> {ok, peerinfo()}.
 init([PeerInfo]) ->
     IP = inet:ntoa(maps:get(ip, PeerInfo)),
     logger:notice("Starting ENet session for ~p", [IP]),
@@ -69,6 +70,7 @@ handle_info({enet, disconnected, remote, _Pid, _When}, PeerInfo) ->
     logger:notice("~p: ENet client disconnected", [IP]),
     {stop, normal, PeerInfo};
 handle_info({enet, Channel, {reliable, Msg}}, PeerInfo) ->
+    logger:notice("Got a reliable msg"),
     decode_and_reply(
         Msg, Channel, {enet, send_reliable}, PeerInfo
     ),
@@ -93,8 +95,21 @@ handle_info(_, PeerInfo) ->
     % Ignore all other messages
     {noreply, PeerInfo}.
 
-terminate(_Reason, _PeerInfo) ->
+%%---------------------------------------------------------------------------
+%% @doc Clean up the ENet handler by calling the session's disconnect callback
+%% @end
+%%---------------------------------------------------------------------------
+-spec terminate(any(), peerinfo()) -> ok.
+terminate(_Reason, #{ session_id := SessionID }) ->
     % We've caught an error or otherwise asked to stop, clean up the session
+    case ow_session:disconnect_callback(SessionID) of
+        {Module, Fun, Args} ->
+            logger:notice("Calling: ~p:~p(~p)", [Module, Fun, Args]),
+            erlang:apply(Module, Fun, Args);
+        undefined ->
+            ok
+    end,
+    {ok, disconnected} = ow_session:status(disconnected, SessionID),
     ok.
 
 code_change(_OldVsn, PeerInfo, _Extra) -> {ok, PeerInfo}.
@@ -113,8 +128,8 @@ decode_and_reply(Msg, _IncomingChannel, _MF, PeerInfo) ->
     case ow_protocol:route(Msg, SessionID) of
         ok ->
             ok;
-        {MsgType, Msg} ->
-            channelize_msg(MsgType, Msg, Channels)
+        {MsgType, Msg1} ->
+            channelize_msg(MsgType, Msg1, Channels)
     end.
 
 channelize_msg(MsgType, Msg, Channels) ->

--- a/src/ow_session_util.erl
+++ b/src/ow_session_util.erl
@@ -34,7 +34,7 @@ session_ping(Msg, SessionID) ->
         round(Now - Last), native, millisecond
     ),
     {ok, Latency} = ow_session:latency(Latency, SessionID),
-    ow_msg:encode(#{latency => Latency}, session_pong).
+    {session_pong, #{latency => Latency}}.
 
 %%----------------------------------------------------------------------------
 %% @doc Request a new session, or rejoin an existing one

--- a/src/ow_session_util.erl
+++ b/src/ow_session_util.erl
@@ -24,7 +24,7 @@
 %% @doc Calculate the latency based on the RTT to the client
 %% @end
 %%----------------------------------------------------------------------------
--spec session_ping(map(), ow_session:id()) -> binary().
+-spec session_ping(map(), ow_session:id()) -> {atom(), map()}.
 session_ping(Msg, SessionID) ->
     BeaconID = maps:get(id, Msg),
     Last = ow_beacon:get_by_id(BeaconID),

--- a/src/ow_websocket.erl
+++ b/src/ow_websocket.erl
@@ -68,8 +68,8 @@ websocket_handle({binary, Msg}, SessionID) ->
     case ow_protocol:route(Msg, SessionID) of
         ok ->
             {ok, SessionID};
-        Msg1 ->
-            {reply, {binary, Msg1}, SessionID}
+        {MsgType, Msg1} ->
+            {reply, {binary, to_binary(MsgType, Msg1)}, SessionID}
     end;
 websocket_handle(Frame, SessionID) ->
     logger:debug("Received some other kind of frame: ~p", [Frame]),

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -130,7 +130,9 @@
     Result :: {Response, State},
     Response :: ow_zone_resp().
 
--optional_callbacks([handle_join/3, handle_part/3, handle_disconnect/2]).
+-optional_callbacks([
+    handle_join/3, handle_part/3, handle_disconnect/2, handle_reconnect/2
+]).
 
 %%=======================================================================
 %% gen_server API functions

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -170,7 +170,6 @@ start_link(Module, Args, Opts) ->
     Opts :: [start_opt()],
     Result :: start_ret().
 start_link(ServerName, Module, Args, Opts) ->
-    % TODO: Check for configuration options in Opts
     gen_server:start_link(ServerName, ?MODULE, {Module, Args}, Opts).
 
 -spec start_monitor(Module, Args, Opts) -> Result when
@@ -301,7 +300,6 @@ handle_call(
                 % Notify the caller of any messages that the callback module
                 % wants to send as a response to the joint
                 handle_notify(Notify, St1),
-                % TODO: maybe set a termination callback?
                 St1;
             false ->
                 % Assume the callback module does not want to take any


### PR DESCRIPTION
This PR ensures that serialization happens in the connection handler. It also specifically ensures that enet is handling disconnect callbacks properly. 

- **ow_session_util.erl**
  - Do not serialize the `session_pong` message here
- **ow_enet.erl**
  - Properly handle disconnects. 
  - Fix for serializing replies
- **ow_websocket.erl**
  - Ensure any replies are serialized
- **ow_zone.erl**
  - cleanup some TODOs