### PR TITLE
Refactor `ow_zone` code

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -62,7 +62,7 @@
 
 {erlfmt, [
     {files, "{src,include,test}/*.{erl,esh,hrl}"},
-    {print_width, 76}
+    {print_width, 96} 
 ]}.
 
 {profiles, [{prod, [{relx, [{dev_mode, false},

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -68,12 +68,18 @@
     {ok, {pid(), reference()}}
     | ignore
     | {error, term()}.
+-type state() :: #state{}.
 -type from() :: gen_server:from().
 -type zone_msg() :: {atom(), map()}.
--type ow_zone_resp() ::
-    noreply
-    | {'@zone', zone_msg()}
-    | {{'@', list()}, zone_msg()}.
+-type ow_zone_call_resp() ::
+    {noreply, state()}
+    | {reply, zone_msg(), state()}
+    | {broadcast, zone_msg(), state()}
+    | {{at, list()}, zone_msg(), state()}.
+-type ow_zone_cast_resp() ::
+    {noreply, state()}
+    | {broadcast, zone_msg(), state()}
+    | {{at, list()}, zone_msg(), state()}.
 -type zone_data() ::
     #{
         clients => [ow_session:id()],
@@ -82,7 +88,6 @@
         lerp_period => pos_integer(),
         disconnect => hard | soft
     }.
--type state() :: #state{}.
 
 %%=======================================================================
 %% ow_zone callbacks
@@ -102,33 +107,28 @@
     From :: ow_session:id(),
     Msg :: term(),
     State :: term(),
-    Result :: {Response, State},
-    Response :: ow_zone_resp().
+    Result :: ow_zone_call_resp().
 
 -callback handle_part(Msg, From, State) -> Result when
     From :: ow_session:id(),
     Msg :: term(),
     State :: term(),
-    Result :: {Response, State},
-    Response :: ow_zone_resp().
-
--callback handle_disconnect(From, State) -> Result when
-    From :: ow_session:id(),
-    State :: term(),
-    Result :: {Response, State},
-    Response :: ow_zone_resp().
+    Result :: ow_zone_call_resp().
 
 -callback handle_reconnect(From, State) -> Result when
     From :: ow_session:id(),
     State :: term(),
-    Result :: {Response, State},
-    Response :: ow_zone_resp().
+    Result :: ow_zone_call_resp().
+
+-callback handle_disconnect(From, State) -> Result when
+    From :: ow_session:id(),
+    State :: term(),
+    Result :: ow_zone_cast_resp().
 
 -callback handle_tick(ZoneData, State) -> Result when
     ZoneData :: zone_data(),
     State :: term(),
-    Result :: {Response, State},
-    Response :: ow_zone_resp().
+    Result :: ow_zone_cast_resp().
 
 -optional_callbacks([
     handle_join/3, handle_part/3, handle_disconnect/2, handle_reconnect/2
@@ -283,109 +283,103 @@ init(_CbMod, ignore) ->
 init(_CbMod, Stop) ->
     Stop.
 
-handle_call(
-    ?TAG_I({join, Msg, Who}),
-    _From,
-    #state{zone_data = ZD} = St0
-) ->
-    logger:notice("Who: ~p", [Who]),
-    % Check the callback module for a handle_join function
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+% 1. Add the player to the player list (THIS IMPLIES VALIDATION IS DONE ELSEWHERE)
+% 2. Check if callback is exported
+% 3. Run the callback
+% 4. Check the output which will be of form {noreply, CbData1} OR {replytype(), msg(), CbData1}
+%    4a. If there is no reply, we're done
+%    4b. If there is a reply, we need to handle it
+
+handle_call(?TAG_I({join, Msg, Who}), _ConnectionHandler, St0) ->
     CbMod = St0#state.cb_mod,
     CbData0 = St0#state.cb_data,
-    State1 =
-        case erlang:function_exported(CbMod, handle_join, 3) of
-            true ->
-                {Notify, CbData1} = CbMod:handle_join(Msg, Who, CbData0),
-                St1 = St0#state{cb_data = CbData1},
-                % Notify the caller of any messages that the callback module
-                % wants to send as a response to the joint
-                handle_notify(Notify, St1),
-                St1;
-            false ->
-                % Assume the callback module does not want to take any
-                % additional action
-                St0
-        end,
-    #{clients := Clients} = ZD,
-    ZD1 = ZD#{clients := [Who | Clients]},
-    % Update the session with zone information
+    % Update the sessions ZonePid
     ZonePid = self(),
     {ok, ZonePid} = ow_session:zone(ZonePid, Who),
     % Update the session with a termination callback
     Callback = {CbMod, disconnect, [ZonePid, Who]},
     {ok, Callback} = ow_session:disconnect_callback(Callback, Who),
-    {reply, ok, State1#state{zone_data = ZD1}};
-handle_call(?TAG_I({part, Msg, Who}), _From, St0) ->
-    St1 = handle_part_inner(Msg, Who, St0),
-    {reply, ok, St1};
+    % Add the client to the client list in the zone data
+    #{clients := Clients} = ZD = St0#state.zone_data,
+    ZD1 = ZD#{clients := [Who | Clients]},
+    St1 = St0#state{zone_data = ZD1},
+    % Run the callback handler, if exported
+    maybe
+        true ?= erlang:function_exported(CbMod, handle_join, 3),
+        {ReplyType, ReplyMsg, CbData1} ?= CbMod:handle_join(Msg, Who, CbData0),
+        CallReply = handle_notify(ReplyType, ReplyMsg, St1),
+        {reply, CallReply, St1#state{cb_data = CbData1}}
+    else
+        false ->
+            % Handler not exported, noop.
+            {reply, ok, St1};
+        {noreply, CbData2} ->
+            % State internal update, but no reply
+            {reply, ok, St1#state{cb_data = CbData2}}
+    end;
+handle_call(?TAG_I({part, Msg, Who}), _ConnectionHandler, St0) ->
+    CbMod = St0#state.cb_mod,
+    CbData0 = St0#state.cb_data,
+    ZD = St0#state.zone_data,
+    % Remove the client from the client list in the zone data
+    #{clients := Clients} = ZD,
+    Clients1 = lists:delete(Who, Clients),
+    ZD1 = ZD#{clients := Clients1},
+    St1 = St0#state{zone_data = ZD1},
+    % Run the callback handler, if exported
+    maybe
+        true ?= erlang:function_exported(CbMod, handle_part, 3),
+        {ReplyType, ReplyMsg, CbData1} ?= CbMod:handle_part(Msg, Who, CbData0),
+        CallMsg = handle_notify(ReplyType, ReplyMsg, St1),
+        {reply, CallMsg, St1#state{cb_data = CbData1}}
+    else
+        false ->
+            % No update
+            {reply, ok, St1};
+        {noreply, CbData2} ->
+            % State internal update, but no reply
+            {reply, ok, St1#state{cb_data = CbData2}}
+    end;
 handle_call(
-    ?TAG_I({disconnect, Who}),
-    _From,
-    St0 = #state{zone_data = #{disconnect := hard}}
-) ->
-    % Run the part handler instead of disconnect
-    St1 = handle_part_inner(#{}, Who, St0),
-    {reply, ok, St1};
-handle_call(
-    ?TAG_I({disconnect, Who}),
-    _From,
+    ?TAG_I({reconnect, Msg, Who}),
+    _ConnectionHandler,
     St0 = #state{zone_data = #{disconnect := soft}}
 ) ->
     CbMod = St0#state.cb_mod,
     CbData0 = St0#state.cb_data,
-    NextState =
-        case erlang:function_exported(CbMod, handle_disconnect, 2) of
-            true ->
-                {Notify, CbData1} = CbMod:handle_disconnect(Who, CbData0),
-                St1 = St0#state{cb_data = CbData1},
-                % Notify the caller of any messages that the callback module
-                % wants to send as a response to the joint
-                handle_notify(Notify, St1),
-                St1;
-            false ->
-                % Assume the callback module does not want to take any
-                % additional action
-                St0
-        end,
-    {reply, ok, NextState};
-handle_call(?TAG_I({Type, Msg, SessionID}), _From, St0) ->
+    % Run the callback handler, if exported
+    maybe
+        true ?= erlang:function_exported(CbMod, handle_reconnect, 3),
+        {ReplyType, ReplyMsg, CbData1} ?= CbMod:handle_reconnect(Msg, Who, CbData0),
+        CallReply = handle_notify(ReplyType, ReplyMsg, St0),
+        {reply, CallReply, St0#state{cb_data = CbData1}}
+    else
+        false ->
+            % Handler not exported, noop.
+            {reply, ok, St0};
+        {noreply, CbData2} ->
+            % State internal update, but no reply
+            {reply, ok, St0#state{cb_data = CbData2}}
+    end;
+handle_call(?TAG_I({Type, Msg, Who}), _ConnectionHandler, St0) ->
     CbMod = St0#state.cb_mod,
-    CbData = St0#state.cb_data,
+    CbData0 = St0#state.cb_data,
     Handler = list_to_existing_atom("handler_" ++ atom_to_list(Type)),
-    {Notify, CbData1} =
-        maybe
-            true ?= erlang:function_exported(CbMod, Handler, 3),
-            CbMod:Handler(Msg, SessionID, CbData)
-        else
-            false ->
-                {reply, ok, CbData}
-        end,
-    St1 = St0#state{cb_data = CbData1},
-    % Send any messages as needed - called for side effects
-    handle_notify(Notify, St1),
-    {reply, ok, St1};
-handle_call(
-    ?TAG_I({reconnect, Who}),
-    _From,
-    St0 = #state{zone_data = #{disconnect := soft}}
-) ->
-    CbMod = St0#state.cb_mod,
-    CbData0 = St0#state.cb_data,
-    NextState =
-        case erlang:function_exported(CbMod, handle_reconnect, 2) of
-            true ->
-                {Notify, CbData1} = CbMod:handle_reconnect(Who, CbData0),
-                St1 = St0#state{cb_data = CbData1},
-                % Notify the caller of any messages that the callback module
-                % wants to send as a response to the joint
-                handle_notify(Notify, St1),
-                St1;
-            false ->
-                % Assume the callback module does not want to take any
-                % additional action
-                St0
-        end,
-    {reply, ok, NextState};
+    maybe
+        true ?= erlang:function_exported(CbMod, Handler, 2),
+        {ReplyType, ReplyMsg, CbData1} ?= CbMod:Handler(Msg, Who, CbData0),
+        CallMsg = handle_notify(ReplyType, ReplyMsg, St0),
+        % Replies other than noreply will probably not be sent anywhere useful
+        {reply, CallMsg, St0#state{cb_data = CbData1}}
+    else
+        false ->
+            % Handler not exported, noop.
+            {reply, ok, St0};
+        {noreply, CbData2} ->
+            % State internal update, but no reply
+            {reply, ok, St0#state{cb_data = CbData2}}
+    end;
 handle_call(Call, _From, St0) ->
     %TODO : Allow fall-through ?
     logger:debug(
@@ -393,52 +387,86 @@ handle_call(Call, _From, St0) ->
     ),
     {reply, ok, St0}.
 
-handle_cast(
-    ?TAG_I({reconnect, Who}),
-    St0 = #state{zone_data = #{disconnect := soft}}
-) ->
+handle_cast(?TAG_I({disconnect, Who}), St0 = #state{zone_data = #{disconnect := hard}}) ->
     CbMod = St0#state.cb_mod,
     CbData0 = St0#state.cb_data,
-    NextState =
-        case erlang:function_exported(CbMod, handle_reconnect, 2) of
-            true ->
-                {Notify, CbData1} = CbMod:handle_reconnect(Who, CbData0),
-                St1 = St0#state{cb_data = CbData1},
-                % Notify the caller of any messages that the callback module
-                % wants to send as a response to the joint
-                handle_notify(Notify, St1),
-                St1;
-            false ->
-                % Assume the callback module does not want to take any
-                % additional action
-                St0
-        end,
-    {noreply, NextState};
+    ZD = St0#state.zone_data,
+    % Remove the client from the client list in the zone data
+    #{clients := Clients} = ZD,
+    Clients1 = lists:delete(Who, Clients),
+    ZD1 = ZD#{clients := Clients1},
+    St1 = St0#state{zone_data = ZD1},
+    % Run the callback handler, if exported
+    maybe
+        true ?= erlang:function_exported(CbMod, handle_part, 3),
+        {ReplyType, ReplyMsg, CbData1} ?= CbMod:handle_part(#{}, Who, CbData0),
+        ok = handle_notify(ReplyType, ReplyMsg, St1),
+        {noreply, St1#state{cb_data = CbData1}}
+    else
+        false ->
+            {noreply, St1};
+        {noreply, CbData2} ->
+            {noreply, St1#state{cb_data = CbData2}}
+    end;
+handle_cast(?TAG_I({disconnect, Who}), St0) ->
+    % For soft disconnects, we don't immediately clean up the player
+    CbMod = St0#state.cb_mod,
+    CbData0 = St0#state.cb_data,
+    maybe
+        true ?= erlang:function_exported(CbMod, handle_disconnect, 2),
+        {ReplyType, ReplyMsg, CbData1} ?= CbMod:handle_part(Who, CbData0),
+        ok = handle_notify(ReplyType, ReplyMsg, St0),
+        {noreply, St0#state{cb_data = CbData1}}
+    else
+        false ->
+            {noreply, St0};
+        {noreply, CbData2} ->
+            {noreply, St0#state{cb_data = CbData2}}
+    end;
 handle_cast(?TAG_I({broadcast, Msg}), St0) ->
-    handle_notify({'@zone', Msg}, St0),
+    ok = handle_notify(broadcast, Msg, St0),
     {noreply, St0};
 handle_cast(?TAG_I({send, IDs, Msg}), St0) ->
-    handle_notify({{'@', IDs}, Msg}, St0),
+    ok = handle_notify({send, IDs}, Msg, St0),
     {noreply, St0};
 handle_cast(Cast, St0) ->
     %TODO : Allow fall-through ?
     logger:debug(
-        "Zone was casted with a message it does not understand: ~p", [Cast]
+        "Zone was casted a message it does not understand: ~p", [Cast]
     ),
     {noreply, St0}.
 
 handle_info(?TAG_I(tick), St0) ->
-    St1 = tick(St0),
-    {noreply, St1};
-handle_info(Msg, #state{cb_mod = CbMod} = St0) ->
-    St1 =
-        case erlang:function_exported(CbMod, handle_info, 2) of
-            false ->
-                St0;
-            true ->
-                info(Msg, St0)
-        end,
-    {noreply, St1}.
+    #state{
+        cb_mod = CbMod,
+        cb_data = CbData0,
+        zone_data = ZoneData
+    } = St0,
+    case CbMod:handle_tick(ZoneData, CbData0) of
+        {noreply, CbData1} ->
+            {noreply, St0#state{cb_data = CbData1}};
+        {ReplyType, Msg, CbData1} ->
+            ok = handle_notify(ReplyType, Msg, St0),
+            {noreply, St0#state{cb_data = CbData1}}
+    end.
+
+% Undocumented handle_info fall-through. TBD if useful, so commented for now.
+%handle_info(Msg, #state{cb_mod = CbMod} = St0) ->
+%    #state{cb_mod = CbMod, cb_data = CbData0} = St0,
+%    maybe
+%        true ?= erlang:function_exported(CbMod, handle_info, 2),
+%        {noreply, CbData1} ?= CbMod:handle_info(Msg, CbData0),
+%        {noreply, St0#state{cb_data = CbData1}}
+%    else
+%        false ->
+%            {noreply, St0};
+%        {reply, _Msg, CbData} ->
+%            logger:warning("Dropping 'reply' message sent to info handler in zone ~p", [self()]),
+%            {noreply, St0#state{cb_data = CbData}};
+%        {MsgType, Msg, CbData} ->
+%            handle_notify(MsgType, Msg, St0),
+%            {noreply, St0#state{cb_data=CbData}}
+%    end.
 
 terminate(_Reason, _St0) -> ok.
 code_change(_OldVsn, St0, _Extra) -> {ok, St0}.
@@ -447,53 +475,18 @@ code_change(_OldVsn, St0, _Extra) -> {ok, St0}.
 %% Internal functions
 %%=======================================================================
 
--spec tick(state()) -> state().
-tick(St0 = #state{cb_mod = CbMod, cb_data = CbData0, zone_data = ZoneData}) ->
-    {Notify, CbData1} = CbMod:handle_tick(ZoneData, CbData0),
-    St1 = St0#state{cb_data = CbData1},
-    handle_notify(Notify, St1),
-    St1.
-
-info(Msg, St0) ->
-    #state{cb_mod = CbMod, cb_data = CbData} = St0,
-    {Notify, CbData1} = CbMod:handle_info(Msg, CbData),
-    St1 = St0#state{cb_data = CbData1},
-    handle_notify(Notify, St1),
-    St1.
-
-handle_part_inner(Msg, Who, #state{zone_data = ZD} = St0) ->
-    CbMod = St0#state.cb_mod,
-    CbData0 = St0#state.cb_data,
-    NextState =
-        case erlang:function_exported(CbMod, handle_part, 3) of
-            true ->
-                {Notify, CbData1} = CbMod:handle_part(Msg, Who, CbData0),
-                St1 = St0#state{cb_data = CbData1},
-                % Send any messages as needed - called for side effects
-                handle_notify(Notify, St1),
-                St1;
-            false ->
-                % Assume the callback module does not want to take any
-                % additional action
-                St0
-        end,
-    #{clients := Clients} = ZD,
-    Clients1 = lists:delete(Who, Clients),
-    ZD1 = ZD#{clients := Clients1},
-    NextState#state{zone_data = ZD1}.
-
-handle_notify({{'@', IDs}, {MsgType, Msg}}, #state{zone_data = ZD}) ->
-    #{clients := Clients} = ZD,
-    % Notify clients that are both in the list to be notified AND a current client
+handle_notify({send, IDs}, {MsgType, Msg}, St0) ->
+    #{clients := Clients} = St0#state.zone_data,
+    % Filter down to only the active clients specified
     Players = [P0 || P0 <- IDs, P1 <- Clients, P0 =:= P1],
-    ow_session_util:notify_clients(MsgType, Msg, Players);
-handle_notify({'@zone', {MsgType, Msg}}, #state{zone_data = ZD}) ->
-    #{clients := Clients} = ZD,
-    % SEND MESSAGE: Send everyone the message
-    ow_session_util:notify_clients(MsgType, Msg, Clients);
-handle_notify(noreply, _St0) ->
-    % NO MESSAGE
-    ok.
+    ok = ow_session_util:notify_clients(MsgType, Msg, Players),
+    ok;
+handle_notify(broadcast, {MsgType, Msg}, St0) ->
+    #{clients := Clients} = St0#state.zone_data,
+    ok = ow_session_util:notify_clients(MsgType, Msg, Clients),
+    ok;
+handle_notify(reply, {MsgType, Msg}, _St0) ->
+    {MsgType, Msg}.
 
 initialize_state(CbMod, CbData, ZoneData) ->
     #{tick_ms := TickMs} = ZoneData,

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -75,11 +75,11 @@
     {noreply, state()}
     | {reply, zone_msg(), state()}
     | {broadcast, zone_msg(), state()}
-    | {{at, list()}, zone_msg(), state()}.
+    | {{send, [ow_session:id()]}, zone_msg(), state()}.
 -type ow_zone_cast_resp() ::
     {noreply, state()}
     | {broadcast, zone_msg(), state()}
-    | {{at, list()}, zone_msg(), state()}.
+    | {{send, [ow_session:id()]}, zone_msg(), state()}.
 -type zone_data() ::
     #{
         clients => [ow_session:id()],


### PR DESCRIPTION
This implements #40

Much like `gen_server:call` and `gen_server:cast` there are two types of callbacks now.

```erlang
-type ow_zone_call_resp() ::
    {noreply, state()}
    | {reply, zone_msg(), state()}
    | {broadcast, zone_msg(), state()}
    | {{send, [ow_session:id()]}, zone_msg(), state()}.
-type ow_zone_cast_resp() ::
    {noreply, state()}
    | {broadcast, zone_msg(), state()}
    | {{send, [ow_session:id()]}, zone_msg(), state()}.
```

call-based functions (join, part, reconnect, any user defined function) use a return type of `ow_zone_call_resp()` and cast-based functions (disconnect, tick) have a return type of `ow_zone_cast_resp()` since it doesn't make sense to reply to a non-existent caller. 