### PR TITLE
More session fixes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,6 @@
 
 {plugins, [
   {rebar3_gpb_plugin, "2.23.1"},
-  rebar3_hex,
   erlfmt
 ]}.
 
@@ -57,7 +56,8 @@
     {git_subdir,
         "https://github.com/whatsapp/eqwalizer.git",
         {branch, "main"},
-        "eqwalizer_rebar3"}}
+        "eqwalizer_rebar3"}},
+  rebar3_hex
 ]}.
 
 {erlfmt, [

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -100,15 +100,7 @@ handle_info(_, PeerInfo) ->
 %%---------------------------------------------------------------------------
 -spec terminate(any(), peerinfo()) -> ok.
 terminate(_Reason, #{session_id := SessionID}) ->
-    % We've caught an error or otherwise asked to stop, clean up the session
-    case ow_session:disconnect_callback(SessionID) of
-        {Module, Fun, Args} ->
-            logger:notice("Calling: ~p:~p(~p)", [Module, Fun, Args]),
-            erlang:apply(Module, Fun, Args);
-        undefined ->
-            ok
-    end,
-    {ok, disconnected} = ow_session:status(disconnected, SessionID),
+    {ok, disconnected} = ow_session_util:disconnect(SessionID),
     ok.
 
 code_change(_OldVsn, PeerInfo, _Extra) -> {ok, PeerInfo}.

--- a/src/ow_enet.erl
+++ b/src/ow_enet.erl
@@ -100,8 +100,7 @@ handle_info(_, PeerInfo) ->
 %%---------------------------------------------------------------------------
 -spec terminate(any(), peerinfo()) -> ok.
 terminate(_Reason, #{session_id := SessionID}) ->
-    {ok, disconnected} = ow_session_util:disconnect(SessionID),
-    ok.
+    ok = ow_session_util:disconnect(SessionID).
 
 code_change(_OldVsn, PeerInfo, _Extra) -> {ok, PeerInfo}.
 

--- a/src/ow_session_util.erl
+++ b/src/ow_session_util.erl
@@ -94,7 +94,7 @@ connect(SessionID) ->
 %%----------------------------------------------------------------------------
 -spec disconnect(ow_session:id()) -> ok.
 disconnect(SessionID) ->
-  % We've caught an error or otherwise asked to stop, clean up the session
+    % We've caught an error or otherwise asked to stop, clean up the session
     case ow_session:disconnect_callback(SessionID) of
         {Module, Fun, Args} ->
             logger:notice("Calling: ~p:~p(~p)", [Module, Fun, Args]),
@@ -103,7 +103,6 @@ disconnect(SessionID) ->
             ok
     end,
     ow_session:status(disconnected, SessionID).
-  
 
 %%----------------------------------------------------------------------------
 %% @doc Unregister an old SessionID and register a new SessionID for the caller

--- a/src/ow_session_util.erl
+++ b/src/ow_session_util.erl
@@ -102,7 +102,8 @@ disconnect(SessionID) ->
         undefined ->
             ok
     end,
-    ow_session:status(disconnected, SessionID).
+    {ok, disconnected} = ow_session:status(disconnected, SessionID),
+    ok.
 
 %%----------------------------------------------------------------------------
 %% @doc Unregister an old SessionID and register a new SessionID for the caller

--- a/src/ow_websocket.erl
+++ b/src/ow_websocket.erl
@@ -37,8 +37,7 @@ init(Req, _St0) ->
 terminate(_Reason, Req, SessionID) ->
     #{peer := {IP, _Port}} = Req,
     logger:notice("~p: WebSocket client disconnected", [IP]),
-    {ok, disconnected} = ow_session_util:disconnect(SessionID),
-    ok.
+    ok = ow_session_util:disconnect(SessionID).
 
 %%---------------------------------------------------------------------------
 %% @doc Set up the initial state of the websocket handler

--- a/src/ow_websocket.erl
+++ b/src/ow_websocket.erl
@@ -37,14 +37,7 @@ init(Req, _St0) ->
 terminate(_Reason, Req, SessionID) ->
     #{peer := {IP, _Port}} = Req,
     logger:notice("~p: WebSocket client disconnected", [IP]),
-    case ow_session:disconnect_callback(SessionID) of
-        {Module, Fun, Args} ->
-            logger:notice("Calling: ~p:~p(~p)", [Module, Fun, Args]),
-            erlang:apply(Module, Fun, Args);
-        undefined ->
-            ok
-    end,
-    {ok, disconnected} = ow_session:status(disconnected, SessionID),
+    {ok, disconnected} = ow_session_util:disconnect(SessionID),
     ok.
 
 %%---------------------------------------------------------------------------


### PR DESCRIPTION
Simplify disconnection by wrapping it into the `ow_session_util` function rather than duplicating the code in the handlers. 