### PR TITLE
Session changes, documentation

### DIFF
--- a/doc/quickstart/intro.md
+++ b/doc/quickstart/intro.md
@@ -1,14 +1,24 @@
-# Quick Start Introduction
-Overworld is designed to interface the worlds of Erlang-based server
-applications with Godot-based clients, In this quickstart, we'll put together a
-simple chat application using Overworld. This application will consist of two
-parts: a **server** which we will build in Erlang, and a **client** which will
-be written in [Godot](https://godotengine.com/).
+# Overworld Tutorials
+These tutorials cover the basics of creating BEAM-powered game servers
+connected with Godot-based game clients using the Overworld framework.
 
-To get data on and off of the wire, we will implement a
-[Protobuf](https://protobuf.dev/) serialization for our Chat protocol,
-automatically generate client and server bindings, and run a chat application
-with a few clients.
+To proceed with the tutorials, you will need to have [Erlang/OTP
+27](https://www.erlang.org/downloads) (or greater) as well as
+[rebar3](https://rebar3.org/) installed on the system you plan to use as your
+game server. For your client, we recommend the latest stable release of the
+[Godot](https://godotengine.com/) 4.x release series.
+
+
+## Quickstart
+In the quickstart tutorial, you will build a Chat server in Erlang that will
+handle clients joining, parting, abruptly disconnecting, and sending chat
+messages over WebSockets. You will learn how to use Overworld's `ow_zone`
+Erlang behaviour, 
+
+On the client side, we will assume some prior working knowledge of Godot and
+focus on the Overworld integration. You will learn how to use the Overworld
+Client Add-on to automatically download and generate a protobuf library for
+communicating with the Overworld server. 
 
 [Creating the server](server.md)
 [Creating the client](client.md)

--- a/doc/sessions/sessions.md
+++ b/doc/sessions/sessions.md
@@ -27,11 +27,7 @@ Sessions have the following properties:
 ## Starting a session
 Sessions are usually started automatically by WebSocket or ENet handlers, but
 in some cases it may be desireable to start a session manually and join it to a
-zone. For example, if you wanted to create a non-player character (NPC) that
-acts as an autonomous agent in a zone, you start a session for that NPC and
-implement all of the relevant message handlers.
-
-To start a session, you will need to call the session supervisor via
+zone. To start a session, you will need to call the session supervisor via
 `ow_session_sup:new/1` and give it some
 [proplist](https://www.erlang.org/docs/26/man/proplists) corresponding to the
 properties of the session process listed in the previous section. For example,
@@ -48,6 +44,24 @@ you could create a session and connect it back to your shell:
 ```
 
 This session would then be able to join any running zone and send/receive
-messages as normal. An NPC could be implemented by creating a `gen_server` or
-`gen_statem` that creates a new session as part of its `init/1` callback and
-then handles events (i.e. via `handle_info/2`) and responds appropriately.
+messages as normal.
+
+This sort of functionality is useful when implementing server-side agents
+(i.e., non-player characters or NPCs). For example, one could to write a module
+that implements either the `gen_server` or `gen_statem` behaviour and creates a
+new session as part of its `init/1` callback, handles events (i.e. via
+`handle_info/2`), and responds appropriately.
+
+## Session discnnects
+Given that network connections cannot be assumed to be perfectly stable,
+sessions in Overworld persist independent of the connection handler (or
+_proxy_) to potentially give clients an opportunity to reconnect to an existing
+session. The Overworld [Zone](../zone/zone.md) behaviour allows for two types of disconnects:
+* **soft**: The `handle_disconnect/2` function is called on the game module
+  implementing the Zone behaviour. The implementor may choose to forward this
+  information to other clients, update some internal state, or do nothing at
+  all. The client is removed from the zone after the `disconnect_timeout` is
+  reached.
+* **hard**: The `handle_part/3` function is called on the game module and the
+  client is immediately removed from the zone. The session persists for
+  `disconnect_timeout` milliseconds and then shuts down.

--- a/doc/sessions/sessions.md
+++ b/doc/sessions/sessions.md
@@ -23,3 +23,31 @@ Sessions have the following properties:
   reconnecting from an aborted connection.
 * **zone**: The Erlang PID of the Zone that the session is currently participating in.
 * **game_data**: Arbitrary game data set by the application, can be any valid Erlang term.
+
+## Starting a session
+Sessions are usually started automatically by WebSocket or ENet handlers, but
+in some cases it may be desireable to start a session manually and join it to a
+zone. For example, if you wanted to create a non-player character (NPC) that
+acts as an autonomous agent in a zone, you start a session for that NPC and
+implement all of the relevant message handlers.
+
+To start a session, you will need to call the session supervisor via
+`ow_session_sup:new/1` and give it some
+[proplist](https://www.erlang.org/docs/26/man/proplists) corresponding to the
+properties of the session process listed in the previous section. For example,
+you could create a session and connect it back to your shell: 
+
+```erlang
+1> Config = [
+    { proxy, self() },
+    { status, connected }
+   ].
+[{proxy,<0.461.0>},{status,connected}]
+2> ow_session_sup:new(Config).
+{ok,<0.536.0>}
+```
+
+This session would then be able to join any running zone and send/receive
+messages as normal. An NPC could be implemented by creating a `gen_server` or
+`gen_statem` that creates a new session as part of its `init/1` callback and
+then handles events (i.e. via `handle_info/2`) and responds appropriately.

--- a/doc/sessions/sessions.md
+++ b/doc/sessions/sessions.md
@@ -1,0 +1,25 @@
+# Sessions
+Every client that connects to an Overworld server first establishes a
+_session_. The client session is independent of the network connection and is a
+stateful process that holds a number of important pieces of metadata about the
+client.
+
+Sessions have the following properties:
+* **id**: A numeric identifier, usually a positive integer
+* **proxy**: An Erlang process id that will receive messages meant for the
+  session. Usually a WebSocket or ENet handler, but can be any Erlang process.
+* **serializer**: The method used to serialize data for a remote procedure
+  calls. Either `protobuf`, for connections over WebSockets/ENet, or
+  `undefined` for messages sent to/from other Erlang processes. In the latter
+  case, messages will be sent as native tuples. 
+* **latency**: The most recent measure of round trip time between
+  client/server, in milliseconds. Only relevant for ENet/WebSocket connections.
+* **disconnect_callback**: The module, function, and argument list that will be
+  called when a disconnect is detected.
+* **disconnect_timeout**: The time (in milliseconds) before a timeout is triggered (default 5000ms).
+* **status**: The connection state. Can be one of `preconnect`, `connected`, or `disconnected`.
+* **token**: Randomly generated binary data that is presented to the client on
+  first connection, and can be used to assert control over a session after
+  reconnecting from an aborted connection.
+* **zone**: The Erlang PID of the Zone that the session is currently participating in.
+* **game_data**: Arbitrary game data set by the application, can be any valid Erlang term.

--- a/src/ow_session.erl
+++ b/src/ow_session.erl
@@ -18,7 +18,9 @@
     latency/2, latency/1,
     game_data/2, game_data/1,
     disconnect_callback/2, disconnect_callback/1,
-    status/2, status/1,
+    status/1,
+    connected/1,
+    disconnected/1,
     token/2, token/1,
     zone/2, zone/1
 ]).
@@ -180,13 +182,20 @@ disconnect_callback(PID) ->
     gen_server:call(PID, get_disconnect_callback).
 
 %%----------------------------------------------------------------------------
-%% @doc Set the connection status. Disconnected sessions will be periodically
-%%      culled.
+%% @doc Set the current session to disconnected state
 %% @end
 %%----------------------------------------------------------------------------
--spec status(status(), pid()) -> {ok, status()}.
-status(Status, PID) ->
-    gen_server:call(PID, {set_status, Status}).
+-spec disconnected(pid()) -> {ok, status()}.
+disconnected(PID) ->
+    gen_server:call(PID, {set_status, disconnected}).
+
+%%----------------------------------------------------------------------------
+%% @doc Set the current session to connected state
+%% @end
+%%----------------------------------------------------------------------------
+-spec connected(pid()) -> {ok, status()}.
+connected(PID) ->
+    gen_server:call(PID, {set_status, connected}).
 
 %%----------------------------------------------------------------------------
 %% @doc Get the connection status. Disconnected sessions will be periodically

--- a/src/ow_session.erl
+++ b/src/ow_session.erl
@@ -61,7 +61,7 @@
 
 -define(DEFAULT_DISCONNECT_TIMEOUT, 5000).
 % A bit hackish, but gives the zone some time to deal with shutdowns
--define(DEFAULT_SHUTDOWN_DELAY, 1000). 
+-define(DEFAULT_SHUTDOWN_DELAY, 1000).
 
 %%===========================================================================
 %% API
@@ -293,8 +293,9 @@ handle_call({set_disconnect_callback, TCB}, _From, Session) ->
     {reply, {ok, TCB}, Session#session{disconnect_callback = TCB}};
 handle_call(get_disconnect_callback, _From, Session) ->
     {reply, Session#session.disconnect_callback, Session};
-handle_call({set_status, Status}, _From, Session) 
-    when Status =:= disconnected ->
+handle_call({set_status, Status}, _From, Session) when
+    Status =:= disconnected
+->
     % On a disconnected session, set a timer to terminate this session
     Timeout = Session#session.disconnect_timeout,
     erlang:send_after(Timeout, self(), maybe_terminate),
@@ -319,10 +320,10 @@ handle_info(maybe_terminate, Session = #session{status = S, zone = Z}) when
     S =:= disconnected;
     S =:= preconnect
 ->
-    case Z of 
-        undefined -> 
+    case Z of
+        undefined ->
             {stop, normal, Session};
-        _ -> 
+        _ ->
             erlang:send_after(?DEFAULT_SHUTDOWN_DELAY, self(), terminate)
     end;
 handle_info(maybe_terminate, Session) ->

--- a/src/ow_session_util.erl
+++ b/src/ow_session_util.erl
@@ -64,13 +64,11 @@ session_request(Msg, SessionPID) ->
             ow_zone:reconnect(ZonePid, PrevSessionPID),
             % Update the session server with the new token
             {ok, NewToken} = ow_session:token(NewToken, PrevSessionPID),
-            % Update the session server with the connected status
-            {ok, connected} = ow_session:status(connected, SessionPID),
             % Stop the temporary session
             ok = ow_session_sup:delete(SessionPID)
     end,
     % Set the status to connected
-    ow_session:status(connected, SessionPID),
+    ow_session:connected(SessionPID),
     % Register the process of the caller
     gproc:reg({p, l, client_session}),
     ok.
@@ -94,7 +92,7 @@ disconnect(SessionPID) ->
         undefined ->
             ok
     end,
-    {ok, disconnected} = ow_session:status(disconnected, SessionPID),
+    {ok, disconnected} = ow_session:disconnected(SessionPID),
     ok.
 
 %%----------------------------------------------------------------------------

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -296,7 +296,7 @@ init(_CbMod, Stop) ->
 %    4a. If there is no reply, we're done
 %    4b. If there is a reply, we need to handle it
 
-handle_call(?TAG_I({join, Msg, Who}), _ConnectionHandler, St0) ->
+handle_call(?TAG_I({join, Msg, Who}), _From, St0) ->
     CbMod = St0#state.cb_mod,
     CbData0 = St0#state.cb_data,
     % Update the sessions ZonePid
@@ -324,7 +324,7 @@ handle_call(?TAG_I({join, Msg, Who}), _ConnectionHandler, St0) ->
             % State internal update, but no reply
             {reply, ok, St1#state{cb_data = CbData2}}
     end;
-handle_call(?TAG_I({part, Msg, Who}), _ConnectionHandler, St0) ->
+handle_call(?TAG_I({part, Msg, Who}), _From, St0) ->
     CbMod = St0#state.cb_mod,
     CbData0 = St0#state.cb_data,
     ZD = St0#state.zone_data,
@@ -348,7 +348,7 @@ handle_call(?TAG_I({part, Msg, Who}), _ConnectionHandler, St0) ->
     end;
 handle_call(
     ?TAG_I({reconnect, Msg, Who}),
-    _ConnectionHandler,
+    _From,
     St0 = #state{zone_data = #{disconnect := soft}}
 ) ->
     CbMod = St0#state.cb_mod,
@@ -367,7 +367,7 @@ handle_call(
             % State internal update, but no reply
             {reply, ok, St0#state{cb_data = CbData2}}
     end;
-handle_call(?TAG_I({Type, Msg, Who}), _ConnectionHandler, St0) ->
+handle_call(?TAG_I({Type, Msg, Who}), _From, St0) ->
     CbMod = St0#state.cb_mod,
     CbData0 = St0#state.cb_data,
     Handler = list_to_existing_atom("handle_" ++ atom_to_list(Type)),


### PR DESCRIPTION
Make the session status more failsafe by changing `ow_session:status/2` to specific setter functions for setting connected/disconnected state. This will avoid having arbitrary states in the session field that might cause things to blow up weirdly. 

Start adding documentation for Sessions.

Made a bunch of cosmetic changes and thought a bit about what kind of information can be accessed about a session during 'part'. 