### PR TITLE
Session state machine, dumb down zones

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -1,5 +1,4 @@
 [
-  {mnesia, [{dir, "/tmp/ow_db"}]},
   {kernel,
 	  [
       {logger_level, debug}]}

--- a/priv/templates/libow4.mustache
+++ b/priv/templates/libow4.mustache
@@ -226,6 +226,4 @@ func _connected(proto = ""):
 
 func _on_session_beacon(id):
 	# Used for latency measurements
-	if debug:
-		print("[DEBUG] Processing a session beacon packet")
 	session_ping(id)

--- a/src/overworld.app.src
+++ b/src/overworld.app.src
@@ -6,7 +6,6 @@
   {applications,
    [kernel,
 	stdlib,
-	mnesia,
 	gproc,
 	cowboy,
 	enet

--- a/src/ow_websocket.erl
+++ b/src/ow_websocket.erl
@@ -81,7 +81,6 @@ websocket_handle(Frame, Pid) ->
 websocket_info({_From, client_msg, {MsgType, Msg}}, Pid) ->
     % Encode the message into binary
     Bin = to_binary(MsgType, Msg),
-    logger:notice("Forwarding a client_msg: ~p", [MsgType]),
     {reply, {binary, Bin}, Pid};
 websocket_info({reconnect_session, Pid1}, _Pid) ->
     {ok, Pid1};

--- a/src/ow_zone.erl
+++ b/src/ow_zone.erl
@@ -320,7 +320,7 @@ handle_call(?TAG_I({join, Msg, Who}), _From, St0) ->
     maybe
         true ?= erlang:function_exported(CbMod, handle_join, 4),
         {ReplyType, ReplyMsg, CbData1} ?= CbMod:handle_join(Msg, Who, ZD, CbData0),
-        CallReply = handle_notify(ReplyType, ReplyMsg, St0),
+        CallReply = handle_notify(ReplyType, ReplyMsg, St1),
         {reply, CallReply, St1#state{cb_data = CbData1}}
     else
         false ->
@@ -352,7 +352,7 @@ handle_call(?TAG_I({part, Msg, Who}), _From, St0) ->
         true ?= is_client(Who, St0),
         true ?= erlang:function_exported(CbMod, handle_part, 4),
         {ReplyType, ReplyMsg, CbData1} ?= CbMod:handle_part(Msg, Who, ZD, CbData0),
-        CallMsg = handle_notify(ReplyType, ReplyMsg, St0),
+        CallMsg = handle_notify(ReplyType, ReplyMsg, St1),
         {reply, CallMsg, St1#state{cb_data = CbData1}}
     else
         false ->


### PR DESCRIPTION
It was starting to become rather nasty to track all of the possible states that a client could be in from the Zone handler, and it wasn't really the Zone's job to do this in the first place.

Instead, I've refactored the session server to be a finite state machine with 3 states: `disconnected`, `connected`, and `active`. 

The zone now only tracks the clients connected. It will still send messages to clients when someone connects, disconnects, or parts, but it won't manage the session states beyond that. 

To help with that, we now send the full ZoneData for every message. i.e., `handle_join/3` now becomes `handle_join/4`. The same for `handle_part`, `handle_disconnect`, and `handle_reconnect` callbacks. 

Callback modules can read the connect client list from the ZoneData and act appropriately. 

Whenever a client leaves a zone, they go back to `connected` state. If they drop their proxy pid (i.e., the connection has been terminated), they will flip over to `disconnected` state and the timeout handler will run. Once triggered, the session will shut down. 
