### PR TITLE
Simpler client implementation

### DIFF
--- a/src/ow_app.erl
+++ b/src/ow_app.erl
@@ -32,7 +32,8 @@ start(_StartType, StartArgs) ->
     Dispatch = cowboy_router:compile([
         {'_', [
             {"/ws", ow_websocket, []},
-            {"/client/manifest", ow_client_lib, []}
+            {"/client/manifest", ow_client_lib, []},
+            {"/client", ow_client, []}
         ]}
     ]),
     % Start Cowboy for Websocket connections
@@ -44,7 +45,7 @@ start(_StartType, StartArgs) ->
     Options = [
         {peer_limit, PeerLimit},
         {channel_limit, ChannelLimit},
-        {compression_mode, zlib}
+        {compression_mode, none}
     ],
     Handler = {ow_enet, start, []},
     enet:start_host(EnetPort, Handler, Options),

--- a/src/ow_client.erl
+++ b/src/ow_client.erl
@@ -1,0 +1,50 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% @doc ow_client returns the bare minimum client in JSON
+%      format, specifying the protobuf schemas and the
+%      opcode prefixes
+% @end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-module(ow_client).
+-behaviour(cowboy_handler).
+
+-export([init/2, protos/0]).
+
+-spec init(cowboy_req:req(), any()) -> {ok, cowboy_req:req(), any()}.
+init(Req, State) ->
+    #{peer := {_RawIP, _Port}} = Req,
+    Reply = client_json(Req),
+    {ok, Reply, State}.
+
+-spec client_json(cowboy_req:req()) -> cowboy_req:req().
+client_json(Req) ->
+    Client = json:encode(protos()),
+    cowboy_req:reply(
+        200,
+        #{
+            <<"content-type">> => <<"application/json">>,
+            <<"content-disposition">> =>
+                <<"attachment; filename=client.json">>
+        },
+        Client,
+        Req
+    ).
+
+-spec protos() -> list().
+protos() ->
+    Protos = ow_protocol:apps(),
+    protos(Protos, []).
+
+-spec protos(list(), list()) -> list().
+protos([], Acc) ->
+    Acc;
+protos([{Prefix, #{app := App}} | Rest], Acc) ->
+    ProtoDir = code:priv_dir(App),
+    ProtoFile = ProtoDir ++ "/proto/" ++ atom_to_list(App) ++ ".proto",
+    logger:notice("~p", [ProtoFile]),
+    {ok, Schema} = file:read_file(ProtoFile),
+    ProtoMap = #{
+        app => App,
+        schema => Schema,
+        prefix => Prefix
+    },
+    protos(Rest, [ProtoMap | Acc]).


### PR DESCRIPTION
To simplify implementations of clients, I make the following changes:

1. Zlib compression is OFF by default. The compression overhead does more harm than good in optimized cases. This still needs to be threaded through to be configurable by apps requiring overworld as a library
2. There's now a simpler client schema interface that is accessible via "http://<overworld server>/client" that returns a JSON document with the prefix code and protobuf schema. 

```
[                                                                                                                                                                                                                                                                                                                                                                                            
  {                                                                                                                                                                                                                                                                                                                                                                                          
    "prefix": 101,                                                                                                                                                                                                                                                                                                                                                                           
    "app": "chat",                                                                                                                                                                                                                                                                                                                                                                           
    "schema": "syntax = \"proto3\";\n\npackage chat;\n\nmessage chat {\n    oneof msg {\n        join        join        = 1;\n        part        part        = 2;\n        channel_msg channel_msg = 3;\n        sync        sync        = 4;\n    }\n}\n\nmessage join {\n    string handle = 1;\n}\n\nmessage part {\n}\n\nmessage channel_msg {\n    string handle = 1;\n    string text = 2;\n}\n\nmessage sync {\n    repeated string handles = 1;\n}\n"                                                                                                                                                                                                                                                                                                                           
  },                                                                                                                                                                                                                                                                                                                                                                                         
  {                                                                                                                                                                                                                                                                                                                                                                                          
    "prefix": 100,                                                                                                                                                                                                                                                                                                                                                                           
    "app": "overworld",                                                                                                                                                                                                                                                                                                                                                                      
    "schema": "syntax = \"proto2\";\n\npackage overworld;\n\n\n/////////////////////////////////////////////////////////\n// Top level message                                   //\n/////////////////////////////////////////////////////////\nmessage overworld {\n    oneof msg {\n        session_request session_request = 1;\n        session_new     session_new     = 2;\n        session_beacon  session_beacon  = 3;\n        session_ping    session_ping    = 4;\n        session_pong    session_pong    = 5;\n    }\n}\n\n/////////////////////////////////////////////////////////\n// Session Messages                                    //\n/////////////////////////////////////////////////////////\n\n// client --> server\nmessage session_request {\n    optional bytes reconnect_token = 1; // secret\n}\n\n// server --> client\nmessage session_new {\n    // initialize a session and send to the client. \n    required uint64 id              = 1; // public\n    required bytes  reconnect_token = 2; // secret\n}\n\n// server --> client\nmessage session_beacon {\n    required uint64 id = 1;\n}\n\n// client --> server\nmessage session_ping {\n    required uint64 id = 1;\n}\n\n// server -> client\nmessage session_pong {\n    // send the most recent estimate for latency back to the client\n    required uint64 latency = 1;\n}\n"                                                                                                                                                                                                      
  }                                                                                                                                                                                                                                                                                                                                                                                          
]     ```